### PR TITLE
Throws error on iOS when user is not found

### DIFF
--- a/ios/LucraSwiftClient.swift
+++ b/ios/LucraSwiftClient.swift
@@ -202,7 +202,7 @@ import LucraSDK
     case .some(let user):
       resolve(sdkUserToMap(user: user))
     case .none:
-      resolve(nil)
+      reject("USER_NOT_FOUND", "User not found", nil)
     }
   }
 


### PR DESCRIPTION
Should get rid of different behaviors on iOS/Android.