### PR TITLE
Add headless startMiniGame API and bump native SDKs to iOS 5.3.0 / An…

### DIFF
--- a/.github/workflows/publish_npm.yml
+++ b/.github/workflows/publish_npm.yml
@@ -22,13 +22,23 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
 
+      - name: Determine release type
+        id: release-type
+        run: |
+          TAG_NAME=${GITHUB_REF#refs/tags/}
+          if echo "$TAG_NAME" | grep -qi 'beta'; then
+            echo "is_beta=true" >> $GITHUB_OUTPUT
+          else
+            echo "is_beta=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Update package.json version
         run: |
           TAG_NAME=${GITHUB_REF#refs/tags/}
           jq --arg version "$TAG_NAME" '.version = $version' package.json > tmp.$$.json && mv tmp.$$.json package.json
 
       - name: Publish package
-        run: npm publish
+        run: npm publish --tag ${{ steps.release-type.outputs.is_beta == 'true' && 'beta' || 'latest' }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -40,4 +50,4 @@ jobs:
           tag_name: ${{ github.ref_name }}
           release_name: Release ${{ github.ref_name }}
           draft: false
-          prerelease: false
+          prerelease: ${{ steps.release-type.outputs.is_beta == 'true' }}

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -110,8 +110,8 @@ repositories {
 def kotlin_version = getExtOrDefault("kotlinVersion")
 
 dependencies {
-  implementation("com.lucrasports.sdk:sdk-core:6.2.0")
-  implementation("com.lucrasports.sdk:sdk-ui:6.2.0")
+  implementation("com.lucrasports.sdk:sdk-core:6.4.0")
+  implementation("com.lucrasports.sdk:sdk-ui:6.4.0")
   coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.4")
   implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.7.0")
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -105,13 +105,14 @@ repositories {
   if (enableLocalIntegrationModeAndroid) mavenLocal()
   mavenCentral()
   google()
+  maven { url "https://central.sonatype.com/repository/maven-snapshots/" }
 }
 
 def kotlin_version = getExtOrDefault("kotlinVersion")
 
 dependencies {
-  implementation("com.lucrasports.sdk:sdk-core:6.4.0")
-  implementation("com.lucrasports.sdk:sdk-ui:6.4.0")
+  implementation("com.lucrasports.sdk:sdk-core:6.4.0-2026-05-11-1778508734-SNAPSHOT")
+  implementation("com.lucrasports.sdk:sdk-ui:6.4.0-2026-05-11-1778508734-SNAPSHOT")
   coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.4")
   implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.7.0")
 

--- a/android/src/main/kotlin/com/lucrasdk/LucraClientModule.kt
+++ b/android/src/main/kotlin/com/lucrasdk/LucraClientModule.kt
@@ -481,7 +481,7 @@ class LucraClientModule(private val context: ReactApplicationContext) :
     }
 
     @ReactMethod
-    fun preloadGeoToken() {
+    fun preloadGeoToken(context: String) {
         LucraClient().preloadGeoToken()
     }
 

--- a/android/src/main/kotlin/com/lucrasdk/LucraClientModule.kt
+++ b/android/src/main/kotlin/com/lucrasdk/LucraClientModule.kt
@@ -35,7 +35,9 @@ import com.lucrasports.sdk.core.contest.GameInteractions
 import com.lucrasports.sdk.core.contest.LocationError
 import com.lucrasports.sdk.core.contest.LucraError
 import com.lucrasports.sdk.core.contest.UserStateError
+import com.lucrasports.sdk.core.contest.minigame.MiniGameInteractions
 import com.lucrasports.sdk.core.contest.recreational.RecreationalGameInteractions
+import com.lucrasports.sdk.core.minigames.LucraMiniGameMode
 import com.lucrasports.sdk.core.contest.tournament.PoolTournament
 import com.lucrasports.sdk.core.convert_credit.LucraConvertToCreditProvider
 import com.lucrasports.sdk.core.convert_credit.LucraConvertToCreditWithdrawMethod
@@ -246,6 +248,18 @@ class LucraClientModule(private val context: ReactApplicationContext) :
                                         "gamesActiveMatchupStarted",
                                         Arguments.makeNativeMap(
                                             bundleOf("id" to event.matchupId)
+                                        )
+                                    )
+
+                                is LucraEvent.MiniGame.Finished ->
+                                    sendEvent(
+                                        context,
+                                        "miniGameFinished",
+                                        Arguments.makeNativeMap(
+                                            bundleOf(
+                                                "gameId" to event.gameId,
+                                                "matchupId" to event.matchupId
+                                            )
                                         )
                                     )
                             }
@@ -462,6 +476,51 @@ class LucraClientModule(private val context: ReactApplicationContext) :
                 is RecreationalGameInteractions.CancelGamesMatchupResult.Success -> promise.resolve(
                     null
                 )
+            }
+        }
+    }
+
+    @ReactMethod
+    fun startMiniGame(
+        gameId: String,
+        gameMode: String,
+        amount: Double,
+        matchupId: String,
+        promise: Promise
+    ) {
+        val parsedMode = when (gameMode.lowercase()) {
+            "practice" -> LucraMiniGameMode.Practice
+            "1v1" -> LucraMiniGameMode.OneVsOne
+            "free_for_all" -> LucraMiniGameMode.FreeForAll
+            "tournament" -> LucraMiniGameMode.Tournament
+            else -> {
+                promise.reject("invalidGameMode", "Invalid MiniGameMode: $gameMode")
+                return
+            }
+        }
+
+        val optionalMatchupId: String? = matchupId.ifEmpty { null }
+        val optionalAmount: Double? = if (amount == 0.0) null else amount
+
+        LucraClient().startMiniGame(
+            gameId = gameId,
+            gameMode = parsedMode,
+            amount = optionalAmount,
+            matchupId = optionalMatchupId,
+        ) { result ->
+            when (result) {
+                is MiniGameInteractions.StartMiniGameResult.Failure -> rejectLucraError(
+                    promise,
+                    result.failure
+                )
+
+                is MiniGameInteractions.StartMiniGameResult.Success -> {
+                    val map = Arguments.createMap()
+                    map.putString("url", result.session.iframeUrl)
+                    map.putString("sessionId", result.session.sessionId)
+                    result.session.matchupId?.let { id -> map.putString("matchupId", id) }
+                    promise.resolve(map)
+                }
             }
         }
     }

--- a/android/src/main/kotlin/com/lucrasdk/LucraClientModule.kt
+++ b/android/src/main/kotlin/com/lucrasdk/LucraClientModule.kt
@@ -481,6 +481,11 @@ class LucraClientModule(private val context: ReactApplicationContext) :
     }
 
     @ReactMethod
+    fun preloadGeoToken() {
+        LucraClient().preloadGeoToken()
+    }
+
+    @ReactMethod
     fun startMiniGame(
         gameId: String,
         gameMode: String,

--- a/docs/1.2.9_headless_interactions.md
+++ b/docs/1.2.9_headless_interactions.md
@@ -4,6 +4,7 @@ Headless functions are API calls that do not display UI. Most require the SDK to
 
 - Games You Play headless APIs: see [GYP headless functions](2.3_gyp_headless_functions.md)
 - Tournament headless APIs: see [Tournament headless functions](3.3_tournaments_headless.md)
+- Mini Games headless APIs: see [Mini Games headless functions](5.1_mini_games_headless.md)
 
 ## Error handling
 

--- a/docs/5.0.0_mini_games.md
+++ b/docs/5.0.0_mini_games.md
@@ -1,0 +1,48 @@
+# Mini Games
+
+Mini Games allows you to launch browser-based games inside your app via a headless API and a provided WebView wrapper component.
+
+## Entry Points
+
+- Headless API to start a mini game session and receive a URL.
+- `MiniGameWebView` component to render the game in a full-screen modal.
+- Present matchup details after the game ends using `LucraSDK.present`.
+
+## Prerequisites
+
+### Peer Dependencies
+
+Mini Games requires two additional peer dependencies:
+
+```sh
+npm install react-native-webview react-native-haptic-feedback
+```
+
+| Package | Minimum Version |
+|---------|----------------|
+| `react-native-webview` | `>=13.0.0` |
+| `react-native-haptic-feedback` | `>=2.0.0` |
+
+### GeoComply Preloading
+
+Before starting a mini game, preload GeoComply tokens for the relevant buy-in context. This should be called early (e.g., when the mini game screen mounts) to avoid delays at game start:
+
+```ts
+import { LucraSDK, GeoComplyContext } from '@lucra-sports/lucra-react-native-sdk';
+
+LucraSDK.preloadGeoToken(GeoComplyContext.CASH_BUY_IN);
+```
+
+`GeoComplyContext` values:
+
+| Value | Description |
+|-------|-------------|
+| `GeoComplyContext.FREE_BUY_IN` | Free-to-play matchups |
+| `GeoComplyContext.CASH_BUY_IN` | Cash buy-in matchups |
+| `GeoComplyContext.DEPOSIT` | Deposit flow |
+| `GeoComplyContext.WITHDRAWAL` | Withdrawal flow |
+
+## Related Docs
+
+- [Mini Games Headless Functions](5.1_mini_games_headless.md)
+- [Mini Games WebView](5.2_mini_games_webview.md)

--- a/docs/5.1_mini_games_headless.md
+++ b/docs/5.1_mini_games_headless.md
@@ -1,0 +1,110 @@
+# Mini Games Headless Functions
+
+[Lucra Headless setup](1.2.9_headless_interactions.md)
+
+Use these APIs to start mini game sessions without showing Lucra UI. All calls require `LucraSDK.init` to be completed and the user configured.
+
+## Start Mini Game
+
+```ts
+import { LucraSDK, MiniGameMode } from '@lucra-sports/lucra-react-native-sdk';
+
+const result = await LucraSDK.startMiniGame(
+  'hoops-web',
+  MiniGameMode.ONE_VS_ONE,
+  5
+);
+```
+
+Parameters:
+
+- `gameId` (string, required): Mini game identifier (e.g., `'hoops-web'`, `'runaway-web'`, `'tappysoccer-web'`).
+- `gameMode` (MiniGameMode, required): Game mode for the session.
+- `amount` (number, optional): Buy-in amount in dollars. Defaults to `0`. Ignored for `PRACTICE` mode.
+- `matchupId` (string, optional): Existing matchup ID to join. Omit to create a new matchup.
+
+`MiniGameMode` values:
+
+| Value | Description |
+|-------|-------------|
+| `MiniGameMode.PRACTICE` | Free practice session (no wager) |
+| `MiniGameMode.ONE_VS_ONE` | 1v1 head-to-head matchup |
+| `MiniGameMode.FREE_FOR_ALL` | Free-for-all matchup |
+| `MiniGameMode.TOURNAMENT` | Tournament entry |
+
+Returns: `StartMiniGameResult`
+
+```ts
+type StartMiniGameResult = {
+  url: string;        // Game URL to load in a WebView
+  sessionId: string;  // Session identifier
+  matchupId?: string; // Matchup ID (not present for practice mode)
+};
+```
+
+Example response:
+
+```json
+{
+  "url": "https://games.lucrasports.com/hoops-web?session=abc123",
+  "sessionId": "abc123",
+  "matchupId": "matchup-456"
+}
+```
+
+Errors that can be thrown:
+
+- `invalidGameMode` — Unrecognized game mode string.
+- `insufficientFunds` — User has insufficient funds for the buy-in amount.
+- `notAllowed` — User is not allowed to perform this operation.
+- `notInitialized` — User has not been initialized.
+- `unverified` — User has not been verified.
+- `missingDemographicInformation` — User has missing demographic information.
+- `locationError` — Location restriction or geo/permission issue.
+- `apiError` — Server/network error from backend.
+- `unknown` / `unknownError` — Unclassified failure from native SDK.
+
+Handling example:
+
+```ts
+try {
+  const result = await LucraSDK.startMiniGame(
+    'hoops-web',
+    MiniGameMode.ONE_VS_ONE,
+    5
+  );
+  // Pass result.url to MiniGameWebView
+} catch (e: any) {
+  switch (e.code) {
+    case 'insufficientFunds':
+      await LucraSDK.present({ name: LucraSDK.FLOW.ADD_FUNDS });
+      break;
+    case 'unverified':
+      await LucraSDK.present({ name: LucraSDK.FLOW.VERIFY_IDENTITY });
+      break;
+    case 'missingDemographicInformation':
+      await LucraSDK.present({ name: LucraSDK.FLOW.DEMOGRAPHIC_COLLECTION });
+      break;
+    case 'locationError':
+      // prompt user to enable/allow location
+      break;
+    default:
+      console.warn(e);
+  }
+}
+```
+
+## Showing Matchup Details After Game
+
+After the game ends, if the session created a matchup you can present the contest details flow:
+
+```ts
+if (result.matchupId) {
+  await LucraSDK.present({
+    name: LucraSDK.FLOW.GAMES_CONTEST_DETAILS,
+    matchupId: result.matchupId,
+  });
+}
+```
+
+See [GYP Flows](2.1_gyp_flows.md) for more on `GAMES_CONTEST_DETAILS`.

--- a/docs/5.2_mini_games_webview.md
+++ b/docs/5.2_mini_games_webview.md
@@ -1,0 +1,88 @@
+# Mini Games WebView
+
+The SDK provides a `MiniGameWebView` component that handles rendering the mini game in a full-screen modal with built-in support for haptic feedback, game-to-native messaging, and close handling.
+
+## Setup
+
+```ts
+import {
+  LucraSDK,
+  MiniGameMode,
+  MiniGameWebView,
+} from '@lucra-sports/lucra-react-native-sdk';
+```
+
+Requires peer dependencies `react-native-webview` (>=13.0.0) and `react-native-haptic-feedback` (>=2.0.0).
+
+## Props
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `url` | `string \| null` | Game URL from `startMiniGame`. The modal is visible when non-null. Set to `null` to dismiss. |
+| `onClose` | `() => void` | Called when the game sends a `close_game` message or the user taps the close button. |
+
+## Usage
+
+```tsx
+import React, { useState, useCallback, useRef, useEffect } from 'react';
+import {
+  LucraSDK,
+  MiniGameMode,
+  GeoComplyContext,
+  MiniGameWebView,
+} from '@lucra-sports/lucra-react-native-sdk';
+
+function MiniGameScreen() {
+  const [gameUrl, setGameUrl] = useState<string | null>(null);
+  const matchupIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    LucraSDK.preloadGeoToken(GeoComplyContext.CASH_BUY_IN);
+  }, []);
+
+  const startGame = async () => {
+    const result = await LucraSDK.startMiniGame(
+      'hoops-web',
+      MiniGameMode.ONE_VS_ONE,
+      5
+    );
+    matchupIdRef.current = result.matchupId ?? null;
+    setGameUrl(result.url);
+  };
+
+  const handleClose = useCallback(() => {
+    const matchupId = matchupIdRef.current;
+    matchupIdRef.current = null;
+    setGameUrl(null);
+
+    // Present matchup details after the modal finishes dismissing
+    if (matchupId) {
+      setTimeout(async () => {
+        await LucraSDK.present({
+          name: LucraSDK.FLOW.GAMES_CONTEST_DETAILS,
+          matchupId,
+        });
+      }, 1000);
+    }
+  }, []);
+
+  return (
+    <>
+      <MiniGameWebView url={gameUrl} onClose={handleClose} />
+      {/* Your game launcher UI here */}
+    </>
+  );
+}
+```
+
+## Behavior
+
+- **Modal**: The game renders in a full-screen slide-up modal. The modal is visible whenever `url` is non-null.
+- **Close button**: A floating close button (top-left) is always visible, allowing the user to exit manually.
+- **Close deduplication**: The component guards against duplicate `close_game` messages from the game — `onClose` is called at most once per session.
+- **Haptic feedback**: The game can request haptic feedback via `haptic_feedback` messages. Supported types: `light`, `soft`, `tiny`, `selection`, `medium`, `success`, `heavy`, `rigid`, `failure`, `warning`.
+- **Logging**: Game log messages (`log` type) are forwarded to `console.log` with the prefix `[MiniGame JS]`.
+
+## Presenting After Close
+
+When presenting a Lucra flow (e.g., contest details) after the game closes, use a `setTimeout` with a 1000ms delay. This ensures the WebView modal has fully dismissed before the new view controller is presented. Without the delay, iOS may log a "view is not in the window hierarchy" warning and the flow will not appear.

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@
 [Games You Play](2.0.0_gyp.md)
 [Tournaments](3.0.0_tournaments.md)
 [Sports You Watch](4.0.0_syw.md)
+[Mini Games](5.0.0_mini_games.md)
 
 ## Theming/Appearance
 [Theming and Appearance](1.2.1_theming.md)

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
     <uses-permission android:name="com.google.android.providers.gsf.permission.READ_GSERVICES" />
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
     <uses-permission android:name="android.permission.USE_BIOMETRIC" />
+    <uses-permission android:name="android.permission.VIBRATE" />
     <uses-feature android:name="android.hardware.camera.autofocus" />
     <uses-feature android:name="android.hardware.camera" />
 

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -38,7 +38,8 @@ buildscript {
       
       google()
       mavenCentral()
-      
+      maven { url "https://central.sonatype.com/repository/maven-snapshots/" }
+
       maven {
         url("$rootDir/../node_modules/detox/Detox-android")
       }

--- a/example/ios/LucrasdkExample.xcodeproj/project.pbxproj
+++ b/example/ios/LucrasdkExample.xcodeproj/project.pbxproj
@@ -12,8 +12,8 @@
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
 		1694CD8789B843FCCF79F6FE /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 8DDA5389320FEF63EB75428A /* PrivacyInfo.xcprivacy */; };
 		19A55ADC92034163B2307133 /* Inter-ExtraLight.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 668E3390796140588141CD6D /* Inter-ExtraLight.ttf */; };
-		33A131AC83CF0993A3BB30B6 /* Pods_LucrasdkExample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 03E5F7183FF8728FACC905D0 /* Pods_LucrasdkExample.framework */; };
 		3C5489FC14A14C08A6B3C77D /* Inter-ExtraBold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 3556A6E84BC943C3ADF5B381 /* Inter-ExtraBold.ttf */; };
+		40D2825A8338854DFF8F3282 /* Pods_LucrasdkExample.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 826E38E317026612CCF700EB /* Pods_LucrasdkExample.framework */; };
 		42BC6802EB4241F19F5440DB /* Inter-Thin.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 7F05699448C246C4AF3791E2 /* Inter-Thin.ttf */; };
 		557FDAA720C94ACD86F223EC /* Inter-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 3255C0686D4B42D38038C1BD /* Inter-Regular.ttf */; };
 		5B2B67C52CCB4CC4006CA9D0 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 5B2B67C42CCB4CC4006CA9D0 /* GoogleService-Info.plist */; };
@@ -26,7 +26,6 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		03E5F7183FF8728FACC905D0 /* Pods_LucrasdkExample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_LucrasdkExample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		13B07F961A680F5B00A75B9A /* LucrasdkExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = LucrasdkExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		13B07FAF1A68108700A75B9A /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = LucrasdkExample/AppDelegate.h; sourceTree = "<group>"; };
 		13B07FB01A68108700A75B9A /* AppDelegate.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = AppDelegate.mm; path = LucrasdkExample/AppDelegate.mm; sourceTree = "<group>"; };
@@ -35,14 +34,15 @@
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = LucrasdkExample/main.m; sourceTree = "<group>"; };
 		3255C0686D4B42D38038C1BD /* Inter-Regular.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Inter-Regular.ttf"; path = "../assets/fonts/Inter-Regular.ttf"; sourceTree = "<group>"; };
 		3556A6E84BC943C3ADF5B381 /* Inter-ExtraBold.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Inter-ExtraBold.ttf"; path = "../assets/fonts/Inter-ExtraBold.ttf"; sourceTree = "<group>"; };
-		508817242E68DA384D68FC16 /* Pods-LucrasdkExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LucrasdkExample.release.xcconfig"; path = "Target Support Files/Pods-LucrasdkExample/Pods-LucrasdkExample.release.xcconfig"; sourceTree = "<group>"; };
 		5B2B67C32CCB4A0A006CA9D0 /* LucrasdkExample.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = LucrasdkExample.entitlements; path = LucrasdkExample/LucrasdkExample.entitlements; sourceTree = "<group>"; };
 		5B2B67C42CCB4CC4006CA9D0 /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		668E3390796140588141CD6D /* Inter-ExtraLight.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Inter-ExtraLight.ttf"; path = "../assets/fonts/Inter-ExtraLight.ttf"; sourceTree = "<group>"; };
 		725DD2B3661B4C2F8D31BCEE /* Inter-SemiBold.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Inter-SemiBold.ttf"; path = "../assets/fonts/Inter-SemiBold.ttf"; sourceTree = "<group>"; };
+		75F7112ED044540DD6FDAB8D /* Pods-LucrasdkExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LucrasdkExample.release.xcconfig"; path = "Target Support Files/Pods-LucrasdkExample/Pods-LucrasdkExample.release.xcconfig"; sourceTree = "<group>"; };
+		7B59D28DE7FF033016E7B13C /* Pods-LucrasdkExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LucrasdkExample.debug.xcconfig"; path = "Target Support Files/Pods-LucrasdkExample/Pods-LucrasdkExample.debug.xcconfig"; sourceTree = "<group>"; };
 		7F05699448C246C4AF3791E2 /* Inter-Thin.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Inter-Thin.ttf"; path = "../assets/fonts/Inter-Thin.ttf"; sourceTree = "<group>"; };
 		81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = LucrasdkExample/LaunchScreen.storyboard; sourceTree = "<group>"; };
-		8A57F2142ED9ED830646BE2E /* Pods-LucrasdkExample.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-LucrasdkExample.debug.xcconfig"; path = "Target Support Files/Pods-LucrasdkExample/Pods-LucrasdkExample.debug.xcconfig"; sourceTree = "<group>"; };
+		826E38E317026612CCF700EB /* Pods_LucrasdkExample.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_LucrasdkExample.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8DDA5389320FEF63EB75428A /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xml; name = PrivacyInfo.xcprivacy; path = LucrasdkExample/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		B1B102E40FDF4B7894CF5F5B /* Inter-Black.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Inter-Black.ttf"; path = "../assets/fonts/Inter-Black.ttf"; sourceTree = "<group>"; };
 		BE684234CF3842F980AC2C5C /* Inter-Light.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Inter-Light.ttf"; path = "../assets/fonts/Inter-Light.ttf"; sourceTree = "<group>"; };
@@ -55,7 +55,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				33A131AC83CF0993A3BB30B6 /* Pods_LucrasdkExample.framework in Frameworks */,
+				40D2825A8338854DFF8F3282 /* Pods_LucrasdkExample.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -77,10 +77,10 @@
 			name = LucrasdkExample;
 			sourceTree = "<group>";
 		};
-		2D16E6871FA4F8E400B85C8A /* Frameworks */ = {
+		23585EFAF026F0497E9CA070 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				03E5F7183FF8728FACC905D0 /* Pods_LucrasdkExample.framework */,
+				826E38E317026612CCF700EB /* Pods_LucrasdkExample.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -115,9 +115,9 @@
 				13B07FAE1A68108700A75B9A /* LucrasdkExample */,
 				832341AE1AAA6A7D00B99B32 /* Libraries */,
 				83CBBA001A601CBA00E9B192 /* Products */,
-				2D16E6871FA4F8E400B85C8A /* Frameworks */,
 				BBD78D7AC51CEA395F1C20DB /* Pods */,
 				59062CADC2A74A42BE35978E /* Resources */,
+				23585EFAF026F0497E9CA070 /* Frameworks */,
 			);
 			indentWidth = 2;
 			sourceTree = "<group>";
@@ -135,8 +135,8 @@
 		BBD78D7AC51CEA395F1C20DB /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				8A57F2142ED9ED830646BE2E /* Pods-LucrasdkExample.debug.xcconfig */,
-				508817242E68DA384D68FC16 /* Pods-LucrasdkExample.release.xcconfig */,
+				7B59D28DE7FF033016E7B13C /* Pods-LucrasdkExample.debug.xcconfig */,
+				75F7112ED044540DD6FDAB8D /* Pods-LucrasdkExample.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -148,15 +148,15 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "LucrasdkExample" */;
 			buildPhases = (
-				48F7D22D768441B8816F8443 /* [CP] Check Pods Manifest.lock */,
+				1CD33C8BE649D86AAF6C9694 /* [CP] Check Pods Manifest.lock */,
 				FD10A7F022414F080027D42C /* Start Packager */,
 				13B07F871A680F5B00A75B9A /* Sources */,
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
-				D222021FC7509A0005DF2292 /* [CP] Embed Pods Frameworks */,
-				D13F003EB1B477070E59C4F2 /* [CP] Copy Pods Resources */,
-				96522F234B9076560158275E /* [CP-User] [RNFB] Core Configuration */,
+				A5F0817470D8F30238332A8C /* [CP] Embed Pods Frameworks */,
+				79B1F812FEC460ED786F98B7 /* [CP] Copy Pods Resources */,
+				5C1C9364273777F8577E369C /* [CP-User] [RNFB] Core Configuration */,
 			);
 			buildRules = (
 			);
@@ -238,7 +238,7 @@
 			shellPath = /bin/sh;
 			shellScript = "set -e\n\nWITH_ENVIRONMENT=\"../node_modules/react-native/scripts/xcode/with-environment.sh\"\nREACT_NATIVE_XCODE=\"../node_modules/react-native/scripts/react-native-xcode.sh\"\n\n/bin/sh -c \"$WITH_ENVIRONMENT $REACT_NATIVE_XCODE\"\n";
 		};
-		48F7D22D768441B8816F8443 /* [CP] Check Pods Manifest.lock */ = {
+		1CD33C8BE649D86AAF6C9694 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -260,7 +260,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		96522F234B9076560158275E /* [CP-User] [RNFB] Core Configuration */ = {
+		5C1C9364273777F8577E369C /* [CP-User] [RNFB] Core Configuration */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -273,7 +273,7 @@
 			shellPath = /bin/sh;
 			shellScript = "#!/usr/bin/env bash\n#\n# Copyright (c) 2016-present Invertase Limited & Contributors\n#\n# Licensed under the Apache License, Version 2.0 (the \"License\");\n# you may not use this library except in compliance with the License.\n# You may obtain a copy of the License at\n#\n#   http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an \"AS IS\" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n# See the License for the specific language governing permissions and\n# limitations under the License.\n#\n\n##########################################################################\n##########################################################################\n#\n#  NOTE THAT IF YOU CHANGE THIS FILE YOU MUST RUN pod install AFTERWARDS\n#\n#  This file is installed as an Xcode build script in the project file\n#  by cocoapods, and you will not see your changes until you pod install\n#\n##########################################################################\n##########################################################################\n\nset -e\n\n_MAX_LOOKUPS=2;\n_SEARCH_RESULT=''\n_RN_ROOT_EXISTS=''\n_CURRENT_LOOKUPS=1\n_JSON_ROOT=\"'react-native'\"\n_JSON_FILE_NAME='firebase.json'\n_JSON_OUTPUT_BASE64='e30=' # { }\n_CURRENT_SEARCH_DIR=${PROJECT_DIR}\n_PLIST_BUDDY=/usr/libexec/PlistBuddy\n_TARGET_PLIST=\"${BUILT_PRODUCTS_DIR}/${INFOPLIST_PATH}\"\n_DSYM_PLIST=\"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Info.plist\"\n\n# plist arrays\n_PLIST_ENTRY_KEYS=()\n_PLIST_ENTRY_TYPES=()\n_PLIST_ENTRY_VALUES=()\n\nfunction setPlistValue {\n  echo \"info:      setting plist entry '$1' of type '$2' in file '$4'\"\n  ${_PLIST_BUDDY} -c \"Add :$1 $2 '$3'\" $4 || echo \"info:      '$1' already exists\"\n}\n\nfunction getFirebaseJsonKeyValue () {\n  if [[ ${_RN_ROOT_EXISTS} ]]; then\n    ruby -Ku -e \"require 'rubygems';require 'json'; output=JSON.parse('$1'); puts output[$_JSON_ROOT]['$2']\"\n  else\n    echo \"\"\n  fi;\n}\n\nfunction jsonBoolToYesNo () {\n  if [[ $1 == \"false\" ]]; then\n    echo \"NO\"\n  elif [[ $1 == \"true\" ]]; then\n    echo \"YES\"\n  else echo \"NO\"\n  fi\n}\n\necho \"info: -> RNFB build script started\"\necho \"info: 1) Locating ${_JSON_FILE_NAME} file:\"\n\nif [[ -z ${_CURRENT_SEARCH_DIR} ]]; then\n  _CURRENT_SEARCH_DIR=$(pwd)\nfi;\n\nwhile true; do\n  _CURRENT_SEARCH_DIR=$(dirname \"$_CURRENT_SEARCH_DIR\")\n  if [[ \"$_CURRENT_SEARCH_DIR\" == \"/\" ]] || [[ ${_CURRENT_LOOKUPS} -gt ${_MAX_LOOKUPS} ]]; then break; fi;\n  echo \"info:      ($_CURRENT_LOOKUPS of $_MAX_LOOKUPS) Searching in '$_CURRENT_SEARCH_DIR' for a ${_JSON_FILE_NAME} file.\"\n  _SEARCH_RESULT=$(find \"$_CURRENT_SEARCH_DIR\" -maxdepth 2 -name ${_JSON_FILE_NAME} -print | /usr/bin/head -n 1)\n  if [[ ${_SEARCH_RESULT} ]]; then\n    echo \"info:      ${_JSON_FILE_NAME} found at $_SEARCH_RESULT\"\n    break;\n  fi;\n  _CURRENT_LOOKUPS=$((_CURRENT_LOOKUPS+1))\ndone\n\nif [[ ${_SEARCH_RESULT} ]]; then\n  _JSON_OUTPUT_RAW=$(cat \"${_SEARCH_RESULT}\")\n  _RN_ROOT_EXISTS=$(ruby -Ku -e \"require 'rubygems';require 'json'; output=JSON.parse('$_JSON_OUTPUT_RAW'); puts output[$_JSON_ROOT]\" || echo '')\n\n  if [[ ${_RN_ROOT_EXISTS} ]]; then\n    if ! python3 --version >/dev/null 2>&1; then echo \"python3 not found, firebase.json file processing error.\" && exit 1; fi\n    _JSON_OUTPUT_BASE64=$(python3 -c 'import json,sys,base64;print(base64.b64encode(bytes(json.dumps(json.loads(open('\"'${_SEARCH_RESULT}'\"', '\"'rb'\"').read())['${_JSON_ROOT}']), '\"'utf-8'\"')).decode())' || echo \"e30=\")\n  fi\n\n  _PLIST_ENTRY_KEYS+=(\"firebase_json_raw\")\n  _PLIST_ENTRY_TYPES+=(\"string\")\n  _PLIST_ENTRY_VALUES+=(\"$_JSON_OUTPUT_BASE64\")\n\n  # config.app_data_collection_default_enabled\n  _APP_DATA_COLLECTION_ENABLED=$(getFirebaseJsonKeyValue \"$_JSON_OUTPUT_RAW\" \"app_data_collection_default_enabled\")\n  if [[ $_APP_DATA_COLLECTION_ENABLED ]]; then\n    _PLIST_ENTRY_KEYS+=(\"FirebaseDataCollectionDefaultEnabled\")\n    _PLIST_ENTRY_TYPES+=(\"bool\")\n    _PLIST_ENTRY_VALUES+=(\"$(jsonBoolToYesNo \"$_APP_DATA_COLLECTION_ENABLED\")\")\n  fi\n\n  # config.analytics_auto_collection_enabled\n  _ANALYTICS_AUTO_COLLECTION=$(getFirebaseJsonKeyValue \"$_JSON_OUTPUT_RAW\" \"analytics_auto_collection_enabled\")\n  if [[ $_ANALYTICS_AUTO_COLLECTION ]]; then\n    _PLIST_ENTRY_KEYS+=(\"FIREBASE_ANALYTICS_COLLECTION_ENABLED\")\n    _PLIST_ENTRY_TYPES+=(\"bool\")\n    _PLIST_ENTRY_VALUES+=(\"$(jsonBoolToYesNo \"$_ANALYTICS_AUTO_COLLECTION\")\")\n  fi\n\n  # config.analytics_collection_deactivated\n  _ANALYTICS_DEACTIVATED=$(getFirebaseJsonKeyValue \"$_JSON_OUTPUT_RAW\" \"analytics_collection_deactivated\")\n  if [[ $_ANALYTICS_DEACTIVATED ]]; then\n    _PLIST_ENTRY_KEYS+=(\"FIREBASE_ANALYTICS_COLLECTION_DEACTIVATED\")\n    _PLIST_ENTRY_TYPES+=(\"bool\")\n    _PLIST_ENTRY_VALUES+=(\"$(jsonBoolToYesNo \"$_ANALYTICS_DEACTIVATED\")\")\n  fi\n\n  # config.analytics_idfv_collection_enabled\n  _ANALYTICS_IDFV_COLLECTION=$(getFirebaseJsonKeyValue \"$_JSON_OUTPUT_RAW\" \"analytics_idfv_collection_enabled\")\n  if [[ $_ANALYTICS_IDFV_COLLECTION ]]; then\n    _PLIST_ENTRY_KEYS+=(\"GOOGLE_ANALYTICS_IDFV_COLLECTION_ENABLED\")\n    _PLIST_ENTRY_TYPES+=(\"bool\")\n    _PLIST_ENTRY_VALUES+=(\"$(jsonBoolToYesNo \"$_ANALYTICS_IDFV_COLLECTION\")\")\n  fi\n\n  # config.analytics_default_allow_analytics_storage\n  _ANALYTICS_STORAGE=$(getFirebaseJsonKeyValue \"$_JSON_OUTPUT_RAW\" \"analytics_default_allow_analytics_storage\")\n  if [[ $_ANALYTICS_STORAGE ]]; then\n    _PLIST_ENTRY_KEYS+=(\"GOOGLE_ANALYTICS_DEFAULT_ALLOW_ANALYTICS_STORAGE\")\n    _PLIST_ENTRY_TYPES+=(\"bool\")\n    _PLIST_ENTRY_VALUES+=(\"$(jsonBoolToYesNo \"$_ANALYTICS_STORAGE\")\")\n  fi\n\n  # config.analytics_default_allow_ad_storage\n  _ANALYTICS_AD_STORAGE=$(getFirebaseJsonKeyValue \"$_JSON_OUTPUT_RAW\" \"analytics_default_allow_ad_storage\")\n  if [[ $_ANALYTICS_AD_STORAGE ]]; then\n    _PLIST_ENTRY_KEYS+=(\"GOOGLE_ANALYTICS_DEFAULT_ALLOW_AD_STORAGE\")\n    _PLIST_ENTRY_TYPES+=(\"bool\")\n    _PLIST_ENTRY_VALUES+=(\"$(jsonBoolToYesNo \"$_ANALYTICS_AD_STORAGE\")\")\n  fi\n\n  # config.analytics_default_allow_ad_user_data\n  _ANALYTICS_AD_USER_DATA=$(getFirebaseJsonKeyValue \"$_JSON_OUTPUT_RAW\" \"analytics_default_allow_ad_user_data\")\n  if [[ $_ANALYTICS_AD_USER_DATA ]]; then\n    _PLIST_ENTRY_KEYS+=(\"GOOGLE_ANALYTICS_DEFAULT_ALLOW_AD_USER_DATA\")\n    _PLIST_ENTRY_TYPES+=(\"bool\")\n    _PLIST_ENTRY_VALUES+=(\"$(jsonBoolToYesNo \"$_ANALYTICS_AD_USER_DATA\")\")\n  fi\n\n  # config.analytics_default_allow_ad_personalization_signals\n  _ANALYTICS_PERSONALIZATION=$(getFirebaseJsonKeyValue \"$_JSON_OUTPUT_RAW\" \"analytics_default_allow_ad_personalization_signals\")\n  if [[ $_ANALYTICS_PERSONALIZATION ]]; then\n    _PLIST_ENTRY_KEYS+=(\"GOOGLE_ANALYTICS_DEFAULT_ALLOW_AD_PERSONALIZATION_SIGNALS\")\n    _PLIST_ENTRY_TYPES+=(\"bool\")\n    _PLIST_ENTRY_VALUES+=(\"$(jsonBoolToYesNo \"$_ANALYTICS_PERSONALIZATION\")\")\n  fi\n\n  # config.analytics_registration_with_ad_network_enabled\n  _ANALYTICS_REGISTRATION_WITH_AD_NETWORK=$(getFirebaseJsonKeyValue \"$_JSON_OUTPUT_RAW\" \"google_analytics_registration_with_ad_network_enabled\")\n  if [[ $_ANALYTICS_REGISTRATION_WITH_AD_NETWORK ]]; then\n    _PLIST_ENTRY_KEYS+=(\"GOOGLE_ANALYTICS_REGISTRATION_WITH_AD_NETWORK_ENABLED\")\n    _PLIST_ENTRY_TYPES+=(\"bool\")\n    _PLIST_ENTRY_VALUES+=(\"$(jsonBoolToYesNo \"$_ANALYTICS_REGISTRATION_WITH_AD_NETWORK\")\")\n  fi\n\n  # config.google_analytics_automatic_screen_reporting_enabled\n  _ANALYTICS_AUTO_SCREEN_REPORTING=$(getFirebaseJsonKeyValue \"$_JSON_OUTPUT_RAW\" \"google_analytics_automatic_screen_reporting_enabled\")\n  if [[ $_ANALYTICS_AUTO_SCREEN_REPORTING ]]; then\n    _PLIST_ENTRY_KEYS+=(\"FirebaseAutomaticScreenReportingEnabled\")\n    _PLIST_ENTRY_TYPES+=(\"bool\")\n    _PLIST_ENTRY_VALUES+=(\"$(jsonBoolToYesNo \"$_ANALYTICS_AUTO_SCREEN_REPORTING\")\")\n  fi\n\n  # config.perf_auto_collection_enabled\n  _PERF_AUTO_COLLECTION=$(getFirebaseJsonKeyValue \"$_JSON_OUTPUT_RAW\" \"perf_auto_collection_enabled\")\n  if [[ $_PERF_AUTO_COLLECTION ]]; then\n    _PLIST_ENTRY_KEYS+=(\"firebase_performance_collection_enabled\")\n    _PLIST_ENTRY_TYPES+=(\"bool\")\n    _PLIST_ENTRY_VALUES+=(\"$(jsonBoolToYesNo \"$_PERF_AUTO_COLLECTION\")\")\n  fi\n\n  # config.perf_collection_deactivated\n  _PERF_DEACTIVATED=$(getFirebaseJsonKeyValue \"$_JSON_OUTPUT_RAW\" \"perf_collection_deactivated\")\n  if [[ $_PERF_DEACTIVATED ]]; then\n    _PLIST_ENTRY_KEYS+=(\"firebase_performance_collection_deactivated\")\n    _PLIST_ENTRY_TYPES+=(\"bool\")\n    _PLIST_ENTRY_VALUES+=(\"$(jsonBoolToYesNo \"$_PERF_DEACTIVATED\")\")\n  fi\n\n  # config.messaging_auto_init_enabled\n  _MESSAGING_AUTO_INIT=$(getFirebaseJsonKeyValue \"$_JSON_OUTPUT_RAW\" \"messaging_auto_init_enabled\")\n  if [[ $_MESSAGING_AUTO_INIT ]]; then\n    _PLIST_ENTRY_KEYS+=(\"FirebaseMessagingAutoInitEnabled\")\n    _PLIST_ENTRY_TYPES+=(\"bool\")\n    _PLIST_ENTRY_VALUES+=(\"$(jsonBoolToYesNo \"$_MESSAGING_AUTO_INIT\")\")\n  fi\n\n  # config.in_app_messaging_auto_colllection_enabled\n  _FIAM_AUTO_INIT=$(getFirebaseJsonKeyValue \"$_JSON_OUTPUT_RAW\" \"in_app_messaging_auto_collection_enabled\")\n  if [[ $_FIAM_AUTO_INIT ]]; then\n    _PLIST_ENTRY_KEYS+=(\"FirebaseInAppMessagingAutomaticDataCollectionEnabled\")\n    _PLIST_ENTRY_TYPES+=(\"bool\")\n    _PLIST_ENTRY_VALUES+=(\"$(jsonBoolToYesNo \"$_FIAM_AUTO_INIT\")\")\n  fi\n\n  # config.app_check_token_auto_refresh\n  _APP_CHECK_TOKEN_AUTO_REFRESH=$(getFirebaseJsonKeyValue \"$_JSON_OUTPUT_RAW\" \"app_check_token_auto_refresh\")\n  if [[ $_APP_CHECK_TOKEN_AUTO_REFRESH ]]; then\n    _PLIST_ENTRY_KEYS+=(\"FirebaseAppCheckTokenAutoRefreshEnabled\")\n    _PLIST_ENTRY_TYPES+=(\"bool\")\n    _PLIST_ENTRY_VALUES+=(\"$(jsonBoolToYesNo \"$_APP_CHECK_TOKEN_AUTO_REFRESH\")\")\n  fi\n\n  # config.crashlytics_disable_auto_disabler - undocumented for now - mainly for debugging, document if becomes useful\n  _CRASHLYTICS_AUTO_DISABLE_ENABLED=$(getFirebaseJsonKeyValue \"$_JSON_OUTPUT_RAW\" \"crashlytics_disable_auto_disabler\")\n  if [[ $_CRASHLYTICS_AUTO_DISABLE_ENABLED == \"true\" ]]; then\n    echo \"Disabled Crashlytics auto disabler.\" # do nothing\n  else\n    _PLIST_ENTRY_KEYS+=(\"FirebaseCrashlyticsCollectionEnabled\")\n    _PLIST_ENTRY_TYPES+=(\"bool\")\n    _PLIST_ENTRY_VALUES+=(\"NO\")\n  fi\nelse\n  _PLIST_ENTRY_KEYS+=(\"firebase_json_raw\")\n  _PLIST_ENTRY_TYPES+=(\"string\")\n  _PLIST_ENTRY_VALUES+=(\"$_JSON_OUTPUT_BASE64\")\n  echo \"warning:   A firebase.json file was not found, whilst this file is optional it is recommended to include it to configure firebase services in React Native Firebase.\"\nfi;\n\necho \"info: 2) Injecting Info.plist entries: \"\n\n# Log out the keys we're adding\nfor i in \"${!_PLIST_ENTRY_KEYS[@]}\"; do\n  echo \"    ->  $i) ${_PLIST_ENTRY_KEYS[$i]}\" \"${_PLIST_ENTRY_TYPES[$i]}\" \"${_PLIST_ENTRY_VALUES[$i]}\"\ndone\n\nfor plist in \"${_TARGET_PLIST}\" \"${_DSYM_PLIST}\" ; do\n  if [[ -f \"${plist}\" ]]; then\n\n    # paths with spaces break the call to setPlistValue. temporarily modify\n    # the shell internal field separator variable (IFS), which normally\n    # includes spaces, to consist only of line breaks\n    oldifs=$IFS\n    IFS=\"\n\"\n\n    for i in \"${!_PLIST_ENTRY_KEYS[@]}\"; do\n      setPlistValue \"${_PLIST_ENTRY_KEYS[$i]}\" \"${_PLIST_ENTRY_TYPES[$i]}\" \"${_PLIST_ENTRY_VALUES[$i]}\" \"${plist}\"\n    done\n\n    # restore the original internal field separator value\n    IFS=$oldifs\n  else\n    echo \"warning:   A Info.plist build output file was not found (${plist})\"\n  fi\ndone\n\necho \"info: <- RNFB build script finished\"\n";
 		};
-		D13F003EB1B477070E59C4F2 /* [CP] Copy Pods Resources */ = {
+		79B1F812FEC460ED786F98B7 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -290,7 +290,7 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-LucrasdkExample/Pods-LucrasdkExample-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		D222021FC7509A0005DF2292 /* [CP] Embed Pods Frameworks */ = {
+		A5F0817470D8F30238332A8C /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -343,7 +343,7 @@
 /* Begin XCBuildConfiguration section */
 		13B07F941A680F5B00A75B9A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 8A57F2142ED9ED830646BE2E /* Pods-LucrasdkExample.debug.xcconfig */;
+			baseConfigurationReference = 7B59D28DE7FF033016E7B13C /* Pods-LucrasdkExample.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
@@ -404,7 +404,7 @@
 		};
 		13B07F951A680F5B00A75B9A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 508817242E68DA384D68FC16 /* Pods-LucrasdkExample.release.xcconfig */;
+			baseConfigurationReference = 75F7112ED044540DD6FDAB8D /* Pods-LucrasdkExample.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;

--- a/example/ios/LucrasdkExample.xcodeproj/project.pbxproj
+++ b/example/ios/LucrasdkExample.xcodeproj/project.pbxproj
@@ -381,7 +381,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4.0;
+				MARKETING_VERSION = 5.3.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
@@ -441,7 +441,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.4.0;
+				MARKETING_VERSION = 5.3.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -100,7 +100,7 @@ PODS:
     - hermes-engine/Pre-built (= 0.79.2)
   - hermes-engine/Pre-built (0.79.2)
   - JWTDecode (3.3.0)
-  - lucra-react-native-sdk (0.0.0):
+  - lucra-react-native-sdk (5.3.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2012,6 +2012,30 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
+  - RNReactNativeHapticFeedback (3.0.0):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
   - RNScreens (4.10.0):
     - DoubleConversion
     - glog
@@ -2175,6 +2199,7 @@ DEPENDENCIES:
   - "RNFBDynamicLinks (from `../node_modules/@react-native-firebase/dynamic-links`)"
   - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
   - RNPermissions (from `../node_modules/react-native-permissions`)
+  - RNReactNativeHapticFeedback (from `../node_modules/react-native-haptic-feedback`)
   - RNScreens (from `../node_modules/react-native-screens`)
   - RNVectorIcons (from `../node_modules/react-native-vector-icons`)
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
@@ -2362,6 +2387,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-gesture-handler"
   RNPermissions:
     :path: "../node_modules/react-native-permissions"
+  RNReactNativeHapticFeedback:
+    :path: "../node_modules/react-native-haptic-feedback"
   RNScreens:
     :path: "../node_modules/react-native-screens"
   RNVectorIcons:
@@ -2392,7 +2419,7 @@ SPEC CHECKSUMS:
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
   hermes-engine: 314be5250afa5692b57b4dd1705959e1973a8ebe
   JWTDecode: 1ca6f765844457d0dd8690436860fecee788f631
-  lucra-react-native-sdk: 9356a6301e100920c7fb470de88c68c4523b33db
+  lucra-react-native-sdk: 2b7612932d198cada416ae73a7f9d2960157dcf9
   LucraSDK: 791d53be085707c9f27eb54980191ab00cba0f7a
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
@@ -2469,6 +2496,7 @@ SPEC CHECKSUMS:
   RNFBDynamicLinks: 3e07d1af77e17bd19bc44aa4f75879a4be98554b
   RNGestureHandler: b249b5be5a3659025aed8898aaaafd567dc2d660
   RNPermissions: d61b587117adb35bb3431dd167d05e775a3db56c
+  RNReactNativeHapticFeedback: 912454bf61e2e99f8d801722bb541acadbc6ca23
   RNScreens: 4ada1709be95c3a4bf1f885378262ceadd9cc939
   RNVectorIcons: 32cc786d5a3c2d8e20ee5c1c7c63c2609f411eb7
   SimpleKeychain: 9c0f3ca8458fed74e01db864d181c5cbe278603e

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Auth0 (2.17.1):
+  - Auth0 (2.19.0):
     - JWTDecode (= 3.3.0)
     - SimpleKeychain (= 1.3.0)
   - boost (1.84.0)
@@ -104,7 +104,7 @@ PODS:
     - DoubleConversion
     - glog
     - hermes-engine
-    - LucraSDK (= 5.1.0)
+    - LucraSDK (= 5.3.0)
     - RCT-Folly (= 2024.11.18.00)
     - RCTRequired
     - RCTTypeSafety
@@ -125,7 +125,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - LucraSDK (5.1.0):
+  - LucraSDK (5.3.0):
     - Auth0
   - nanopb (3.30910.0):
     - nanopb/decode (= 3.30910.0)
@@ -1556,6 +1556,30 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
+  - react-native-webview (13.16.1):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
   - React-NativeModulesApple (0.79.2):
     - glog
     - hermes-engine
@@ -2111,6 +2135,7 @@ DEPENDENCIES:
   - React-microtasksnativemodule (from `../node_modules/react-native/ReactCommon/react/nativemodule/microtasks`)
   - react-native-date-picker (from `../node_modules/react-native-date-picker`)
   - react-native-safe-area-context (from `../node_modules/react-native-safe-area-context`)
+  - react-native-webview (from `../node_modules/react-native-webview`)
   - React-NativeModulesApple (from `../node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios`)
   - React-oscompat (from `../node_modules/react-native/ReactCommon/oscompat`)
   - React-perflogger (from `../node_modules/react-native/ReactCommon/reactperflogger`)
@@ -2256,6 +2281,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-date-picker"
   react-native-safe-area-context:
     :path: "../node_modules/react-native-safe-area-context"
+  react-native-webview:
+    :path: "../node_modules/react-native-webview"
   React-NativeModulesApple:
     :path: "../node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios"
   React-oscompat:
@@ -2348,7 +2375,7 @@ CHECKOUT OPTIONS:
     :git: https://github.com/ospfranco/Resolver.git
 
 SPEC CHECKSUMS:
-  Auth0: f51675227edd4a2db0b8f6d4bdd6144acc5552b8
+  Auth0: edcdfffffb453a18cc15e122a04f284c913136d6
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
   fast_float: 06eeec4fe712a76acc9376682e4808b05ce978b6
@@ -2365,84 +2392,85 @@ SPEC CHECKSUMS:
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
   hermes-engine: 314be5250afa5692b57b4dd1705959e1973a8ebe
   JWTDecode: 1ca6f765844457d0dd8690436860fecee788f631
-  lucra-react-native-sdk: f53ef0ab4d841e8382712a2b82806174c0d08a6c
-  LucraSDK: 8861cc550c1a230133d2b103745812157ced751b
+  lucra-react-native-sdk: 9356a6301e100920c7fb470de88c68c4523b33db
+  LucraSDK: 791d53be085707c9f27eb54980191ab00cba0f7a
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
-  RCT-Folly: e78785aa9ba2ed998ea4151e314036f6c49e6d82
+  RCT-Folly: 36fe2295e44b10d831836cc0d1daec5f8abcf809
   RCTDeprecation: 83ffb90c23ee5cea353bd32008a7bca100908f8c
   RCTRequired: eb7c0aba998009f47a540bec9e9d69a54f68136e
   RCTTypeSafety: 659ae318c09de0477fd27bbc9e140071c7ea5c93
   React: c2d3aa44c49bb34e4dfd49d3ee92da5ebacc1c1c
   React-callinvoker: 1bdfb7549b5af266d85757193b5069f60659ef9d
-  React-Core: 10597593fdbae06f0089881e025a172e51d4a769
-  React-CoreModules: 6907b255529dd46895cf687daa67b24484a612c2
-  React-cxxreact: a9f5b8180d6955bc3f6a3fcd657c4d9b4d95c1f6
+  React-Core: 7150cf9b6a5af063b37003062689f1691e79c020
+  React-CoreModules: 15a85e6665d61678942da6ae485b351f4c699049
+  React-cxxreact: 74f9de59259ac951923f5726aa14f0398f167af9
   React-debug: a9861ea2196e886642887e29fd1d86c6eee93454
-  React-defaultsnativemodule: 48bed05d5e7a6b90c63775bc042acba50f1ac46c
-  React-domnativemodule: 4603dc552b8f2b75cfd708b6175f0f3ab005d661
-  React-Fabric: c48e870a557e39fc38c49bf2f43a62f837876318
-  React-FabricComponents: d0c0029b9066819e736ee70ce8481fe52632ccad
-  React-FabricImage: a843d50c9d21f4a6255c3cd1654cdf16209ac76d
+  React-defaultsnativemodule: 0e85419763d183f937ec98ea01a27a2afd6f1aa2
+  React-domnativemodule: 9b970dcaf8fe53250622daba1d42877f400b858b
+  React-Fabric: 0be44adc205b650b4f6003fd8dd3d72b3a9ba6a8
+  React-FabricComponents: ea062466367976df752a9d5847c7136a7f07bb3d
+  React-FabricImage: 3add4d33413771218a062920378f3dac2abe6502
   React-featureflags: 4ef61c283dfae8f327dbae70f41bb0399bd9e0fc
-  React-featureflagsnativemodule: 879cdf94179dc7395f28b9bf0fd340fd45c05ab7
-  React-graphics: 4e247c50991de6e2c0abd25f8367cfa3113198c0
-  React-hermes: 9116d4e6d07abeb519a2852672de087f44da8f12
-  React-idlecallbacksnativemodule: 5fd6d838b045d3f5b630a6a0714635bc9c882fdc
-  React-ImageManager: ad3f561d76883d6f7f1cf3a97e823fa39ca1b132
-  React-jserrorhandler: 35d127a39a5bc16d9ae97edce7ab4c06dc77e3a2
-  React-jsi: 753ba30c902f3a41fa7f956aca8eea3317a44ee6
-  React-jsiexecutor: 47520714aa7d9589c51c0f3713dfbfca4895d4f9
-  React-jsinspector: ec984e95482ee98692ec74f78771447599ed9781
-  React-jsinspectortracing: 7bd661f34f08b320bb797dc464d6002116fca145
-  React-jsitooling: 90d7ecbb60f70d12f60a4964dfcad0e38d9d970d
-  React-jsitracing: a9de0d25bf430574dc01f1fe67f06fd50e8a578c
-  React-logger: 8edfcedc100544791cd82692ca5a574240a16219
-  React-Mapbuffer: da73f30b000114058d6bc41490dcce204a8ede32
-  React-microtasksnativemodule: 444c5701aece79629bb73bd9e7ad8937ae65238c
-  react-native-date-picker: c568e29cbe8203fbc94651929dac06b8d54a7aa6
-  react-native-safe-area-context: 5928d84c879db2f9eb6969ca70e68f58623dbf25
-  React-NativeModulesApple: df8e5bc59e78ca3040ffbf41336889f3bd0fad68
+  React-featureflagsnativemodule: 3324bd2b55b374897914cf8c6d03cc3c35889d86
+  React-graphics: 29570df7b0b3d210ba5a4ec67024b117b5a8c74a
+  React-hermes: 8b86e5f54a65ecb69cdf22b3a00a11562eda82d2
+  React-idlecallbacksnativemodule: 8624d07a1b25045419521d5809cdf3c948dbc411
+  React-ImageManager: 21a10bb92dde7cf5ec29c139769630dadbac0cc2
+  React-jserrorhandler: 00697e19cde827e8134d543b404f3f016616e8bc
+  React-jsi: 6af1987cfbb1b6621664fdbf6c7b62bd4d38c923
+  React-jsiexecutor: 51f372998e0303585cb0317232b938d694663cbd
+  React-jsinspector: d797824c7b7c931c5ad8ab41de3841a3d7a52e6f
+  React-jsinspectortracing: d9acc748525e22e4c7b7241ea39ecbd99bfa6c22
+  React-jsitooling: 5bf7d347f145ae47bcecd4107ba7fe7539ebf55b
+  React-jsitracing: 6e27cce907f23131472594523cd6e30737a754e5
+  React-logger: 368570a253f00879a1e4fea24ed4047e72e7bbf3
+  React-Mapbuffer: f581f01e9c766bbfb7d1f57a6f6ceb86bdc310f1
+  React-microtasksnativemodule: 8fc1bfccd27980ed6cfec1f52ffcd6af336f48f7
+  react-native-date-picker: 152b88cc5dcf23eb0d2370cebcc35dacbc57a2d6
+  react-native-safe-area-context: 6cec90ce53951d3b52dc73e873323a4a7662fc0c
+  react-native-webview: 97e991a9d3ea6dc06c4b43c38875d8d29d61a801
+  React-NativeModulesApple: 1b5e6bf9164371771e553f744da801f5d9f5c7e5
   React-oscompat: ef5df1c734f19b8003e149317d041b8ce1f7d29c
-  React-perflogger: 9a151e0b4c933c9205fd648c246506a83f31395d
-  React-performancetimeline: d6a5fd3640c873875badb33020ebe5af46ef2a12
+  React-perflogger: 6fd2f6811533e9c19a61e855c3033eecbf4ad2a0
+  React-performancetimeline: df331d0764cc54204a73960408371111efbd34b7
   React-RCTActionSheet: a499b0d6d9793886b67ba3e16046a3fef2cdbbc3
-  React-RCTAnimation: cc64adc259aabc3354b73065e2231d796dfce576
-  React-RCTAppDelegate: 9d523da768f1c9e84c5f3b7e3624d097dfb0e16b
-  React-RCTBlob: e727f53eeefded7e6432eb76bd22b57bc880e5d1
-  React-RCTFabric: a704a0eea3a9a32621ccc79261fe5b010bfcaccb
-  React-RCTFBReactNativeSpec: 9064c63d99e467a3893e328ba3612745c3c3a338
-  React-RCTImage: 7159cbdbb18a09d97ba1a611416eced75b3ccb29
-  React-RCTLinking: 46293afdb859bccc63e1d3dedc6901a3c04ef360
-  React-RCTNetwork: 4a6cd18f5bcd0363657789c64043123a896b1170
-  React-RCTRuntime: 4b47b6380420e9fbfb4bd3cc16d6ea988640ddc1
-  React-RCTSettings: 61e361dc85136d1cb0e148b7541993d2ee950ea7
-  React-RCTText: abd1e196c3167175e6baef18199c6d9d8ac54b4e
-  React-RCTVibration: 490e0dcb01a3fe4a0dfb7bc51ad5856d8b84f343
+  React-RCTAnimation: 2595dcb10a82216a511b54742f8c28d793852ac6
+  React-RCTAppDelegate: f03604b70f57c9469a84a159d8abecf793a5bcff
+  React-RCTBlob: e00f9b4e2f151938f4d9864cf33ebf24ac03328a
+  React-RCTFabric: d3c06acaa6f6b4f51b37b24c1ae5393f55a2ff22
+  React-RCTFBReactNativeSpec: 0f4d4f0da938101f2ca9d5333a8f46e527ad2819
+  React-RCTImage: dac5e9f8ec476aefe6e60ee640ebc1dfaf1a4dbe
+  React-RCTLinking: 494b785a40d952a1dfbe712f43214376e5f0e408
+  React-RCTNetwork: b3d7c30cd21793e268db107dd0980cb61b3c1c44
+  React-RCTRuntime: 8137d4927804480c952a40c422e40a6e697c616f
+  React-RCTSettings: a060c7e381a3896104761b8eed7e284d95e37df3
+  React-RCTText: 4f272b72dbb61f390d8c8274528f9fdbff983806
+  React-RCTVibration: 0e5326220719aca12473d703aa46693e3b4ce67a
   React-rendererconsistency: 68db5a64f0c42b0337e25ba7b0e9513caae1389d
-  React-renderercss: 59c892b54a92f2f62b98c2700f5ff7592f0629cb
-  React-rendererdebug: f9dfe8ef736c98268f87114d05f49615f7f9af46
+  React-renderercss: eeb482d2790028a9b47ce9c214397ae2f4e2a7c5
+  React-rendererdebug: c6e3b7583c2f0802cb3b4cf19f714853fa9ac670
   React-rncore: 0f64cacb1becc6f89c99018ca920d012f9044ebd
-  React-RuntimeApple: f2bc2dc51b9b3c194c0eec4351ae99d033485792
-  React-RuntimeCore: 4e5475d506e7f9c4b3f3c6e6a654b83cba7f1a42
+  React-RuntimeApple: 3d34bd566375cbb61e94360329835fde05ced395
+  React-RuntimeCore: 6140c26964655b66ddc8afb744c9df429f833357
   React-runtimeexecutor: d60846710facedd1edb70c08b738119b3ee2c6c2
-  React-RuntimeHermes: 2b238368a56fc50e9372afde7a3f2eeb0cdc63a7
-  React-runtimescheduler: c65050ab5c3911dd553bb9223c76543198c5854f
+  React-RuntimeHermes: 00ee3577308f9644df029168aa874ac75f25d710
+  React-runtimescheduler: 2ad0d683dd8eac942e03cea82d45982fd5fac362
   React-timing: beb0ba912f9ffc1a6758afa767ae5c03302dc9ee
-  React-utils: 4b32801a05eff845d316edd59b313a3e25c5fc08
-  ReactAppDependencyProvider: 04d5eb15eb46be6720e17a4a7fa92940a776e584
-  ReactCodegen: 041559ba76d00f6680dfa0916b3c791f4babe5ea
-  ReactCommon: 1511ef100f1afa4c199fe52fe7a8d2529a41429a
+  React-utils: 5593ad221337dddfc69230fc32e94af714773ce5
+  ReactAppDependencyProvider: d5dcc564f129632276bd3184e60f053fcd574d6b
+  ReactCodegen: aea17732a7f6a3169e3b2800c58dc12034f874f9
+  ReactCommon: 35a5629d7159876dd048c63751eaeb3aa3a6a53b
   Resolver: 89e3fa61be7350b5faa3cb45cef11c2d9f6a7b2b
-  RNCAsyncStorage: 646c1bf2ebfc78d6632a3b0399f471fba8101e73
-  RNCClipboard: 055cd8f50702b9ebc5a58f7622e0cda073878d21
-  RNFBAnalytics: 03c83ba4617a3754c99e66267983efcc908932a9
-  RNFBApp: a448037d2df74af9d374a0b765be12ff1e844dc0
-  RNFBDynamicLinks: 741b5407a43c906801fe1fc4095d86456eba9892
-  RNGestureHandler: 381f81c675883fec9f8f10976aa278babc48d8eb
-  RNPermissions: fed3371d323a985b377ac56a74c1b9e574211e5d
-  RNScreens: a25b818417609cbd805474dffd2d28b229704cfc
-  RNVectorIcons: fe9afebb925c9ce70f441b611d679e402ecb3f6e
+  RNCAsyncStorage: e25fda4679876e5204c4c502d297757ec1f17ced
+  RNCClipboard: dfcfff4ab54bba045a73273c00ab60a90940388b
+  RNFBAnalytics: caec446c723d33cfdcf75aab53fa1287e499b2d0
+  RNFBApp: fda4a8b08fe31bea8492808106aa638d1bb595b7
+  RNFBDynamicLinks: 3e07d1af77e17bd19bc44aa4f75879a4be98554b
+  RNGestureHandler: b249b5be5a3659025aed8898aaaafd567dc2d660
+  RNPermissions: d61b587117adb35bb3431dd167d05e775a3db56c
+  RNScreens: 4ada1709be95c3a4bf1f885378262ceadd9cc939
+  RNVectorIcons: 32cc786d5a3c2d8e20ee5c1c7c63c2609f411eb7
   SimpleKeychain: 9c0f3ca8458fed74e01db864d181c5cbe278603e
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: 50518ade05048235d91a78b803336dbb5b159d5d

--- a/example/package.json
+++ b/example/package.json
@@ -37,7 +37,7 @@
     "react-native-safe-area-context": "^5.4.0",
     "react-native-screens": "^4.10.0",
     "react-native-vector-icons": "^10.2.0",
-    "react-native-webview": "^13.12.0",
+    "react-native-webview": "^13.14.0",
     "reanimated-color-picker": "^4.0.1"
   },
   "devDependencies": {

--- a/example/package.json
+++ b/example/package.json
@@ -36,6 +36,7 @@
     "react-native-safe-area-context": "^5.4.0",
     "react-native-screens": "^4.10.0",
     "react-native-vector-icons": "^10.2.0",
+    "react-native-webview": "^13.12.0",
     "reanimated-color-picker": "^4.0.1"
   },
   "devDependencies": {

--- a/example/package.json
+++ b/example/package.json
@@ -32,6 +32,7 @@
     "react-native": "^0.79.2",
     "react-native-date-picker": "^5.0.12",
     "react-native-gesture-handler": "^2.25.0",
+    "react-native-haptic-feedback": "^3.0.0",
     "react-native-permissions": "^5.0.2",
     "react-native-safe-area-context": "^5.4.0",
     "react-native-screens": "^4.10.0",

--- a/example/src/Routes.tsx
+++ b/example/src/Routes.tsx
@@ -9,6 +9,7 @@ import { UIEmbeddedPublicFeed } from './container/UIEmbeddedPublicFeed';
 import { EventViewer } from './container/EventViewer';
 import { SportsYouWatch } from './container/APIExample/SportsYouWatch';
 import { GamesYouPlay } from './container/APIExample/GamesYouPlay';
+import { MiniGameLauncher } from './container/MiniGameLauncher';
 
 export type RootStackParamList = {
   Main: undefined;
@@ -20,6 +21,7 @@ export type RootStackParamList = {
   EventViewer: undefined;
   SportsYouWatch: undefined;
   GamesYouPlay: undefined;
+  MiniGameLauncher: undefined;
 };
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
@@ -92,6 +94,13 @@ export const Routes: FC = () => {
       <Stack.Screen
         name="GamesYouPlay"
         component={GamesYouPlay}
+        options={{
+          headerShown: false,
+        }}
+      />
+      <Stack.Screen
+        name="MiniGameLauncher"
+        component={MiniGameLauncher}
         options={{
           headerShown: false,
         }}

--- a/example/src/container/Main.container.tsx
+++ b/example/src/container/Main.container.tsx
@@ -58,6 +58,17 @@ export const MainContainer: React.FC<Props> = ({ navigation }) => {
           </TouchableOpacity>
         </View>
         <View className="mt-4 gap-0.5">
+          <Text className="text-white">Mini Games</Text>
+          <TouchableOpacity
+            className="mt-2 bg-indigo-700 p-4 rounded-xl"
+            onPress={() => {
+              navigation.navigate('MiniGameLauncher');
+            }}
+          >
+            <Text className="text-white">Mini Game Launcher</Text>
+          </TouchableOpacity>
+        </View>
+        <View className="mt-4 gap-0.5">
           <Text className="text-white">Configuration</Text>
           <TouchableOpacity
             className="mt-2 bg-indigo-700 p-4 rounded-t-xl "

--- a/example/src/container/MiniGameLauncher.tsx
+++ b/example/src/container/MiniGameLauncher.tsx
@@ -35,7 +35,6 @@ const GAME_MODES = [
 export const MiniGameLauncher: React.FC<Props> = ({ navigation }) => {
   useEffect(() => {
     LucraSDK.preloadGeoToken(GeoComplyContext.CASH_BUY_IN);
-    LucraSDK.preloadGeoToken(GeoComplyContext.FREE_BUY_IN);
   }, []);
 
   const [gameId, setGameId] = useState('');

--- a/example/src/container/MiniGameLauncher.tsx
+++ b/example/src/container/MiniGameLauncher.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
   Image,
   KeyboardAvoidingView,
@@ -61,6 +61,10 @@ function triggerHaptic(type: string) {
 }
 
 export const MiniGameLauncher: React.FC<Props> = ({ navigation }) => {
+  useEffect(() => {
+    LucraSDK.preloadGeoToken();
+  }, []);
+
   const [gameId, setGameId] = useState('');
   const [gameMode, setGameMode] = useState<MiniGameMode>(
     MiniGameMode.PRACTICE

--- a/example/src/container/MiniGameLauncher.tsx
+++ b/example/src/container/MiniGameLauncher.tsx
@@ -2,11 +2,9 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
   Image,
   KeyboardAvoidingView,
-  Modal,
   Platform,
   SafeAreaView,
   ScrollView,
-  StatusBar,
   StyleSheet,
   Text,
   TextInput,
@@ -15,16 +13,14 @@ import {
   ActivityIndicator,
   Alert,
 } from 'react-native';
-import ReactNativeHapticFeedback, {
-  type HapticFeedbackTypes,
-} from 'react-native-haptic-feedback';
-import { WebView, type WebViewMessageEvent } from 'react-native-webview';
 import { Assets } from '../Assets';
 import type { RootStackParamList } from '../Routes';
 import type { NativeStackScreenProps } from '@react-navigation/native-stack';
 import {
   LucraSDK,
   MiniGameMode,
+  GeoComplyContext,
+  MiniGameWebView,
 } from '@lucra-sports/lucra-react-native-sdk';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'MiniGameLauncher'>;
@@ -36,29 +32,10 @@ const GAME_MODES = [
   { label: 'Tournament', value: MiniGameMode.TOURNAMENT },
 ];
 
-const HAPTIC_MAP: Record<string, HapticFeedbackTypes> = {
-  light: 'impactLight',
-  soft: 'soft',
-  tiny: 'impactLight',
-  selection: 'selection',
-  medium: 'impactMedium',
-  success: 'notificationSuccess',
-  heavy: 'impactHeavy',
-  rigid: 'rigid',
-  failure: 'notificationError',
-  warning: 'notificationWarning',
-};
-
-function triggerHaptic(type: string) {
-  try {
-    const key = type.toLowerCase();
-    ReactNativeHapticFeedback.trigger(HAPTIC_MAP[key] ?? 'impactLight');
-  } catch {}
-}
-
 export const MiniGameLauncher: React.FC<Props> = ({ navigation }) => {
   useEffect(() => {
-    LucraSDK.preloadGeoToken();
+    LucraSDK.preloadGeoToken(GeoComplyContext.CASH_BUY_IN);
+    LucraSDK.preloadGeoToken(GeoComplyContext.FREE_BUY_IN);
   }, []);
 
   const [gameId, setGameId] = useState('');
@@ -70,6 +47,7 @@ export const MiniGameLauncher: React.FC<Props> = ({ navigation }) => {
   const [loading, setLoading] = useState(false);
   const [gameUrl, setGameUrl] = useState<string | null>(null);
   const resultMatchupIdRef = useRef<string | null>(null);
+  const [pendingMatchupId, setPendingMatchupId] = useState<string | null>(null);
 
   const handleStartMiniGame = async () => {
     if (!gameId.trim()) {
@@ -86,6 +64,7 @@ export const MiniGameLauncher: React.FC<Props> = ({ navigation }) => {
         gameMode === MiniGameMode.PRACTICE ? 0 : amount,
         matchupId.trim() || undefined
       );
+      console.log('[MiniGame] startMiniGame result:', JSON.stringify(result));
       resultMatchupIdRef.current = result.matchupId ?? null;
       setGameUrl(result.url);
     } catch (e: any) {
@@ -95,123 +74,41 @@ export const MiniGameLauncher: React.FC<Props> = ({ navigation }) => {
     }
   };
 
-  const [pendingMatchupId, setPendingMatchupId] = useState<string | null>(null);
-
   const closeGame = useCallback(() => {
     const returnedMatchupId = resultMatchupIdRef.current;
+    console.log('[MiniGame] closeGame called, matchupId:', returnedMatchupId, 'gameUrl:', gameUrl);
     resultMatchupIdRef.current = null;
     if (returnedMatchupId) {
       setPendingMatchupId(returnedMatchupId);
     }
     setGameUrl(null);
-  }, []);
+  }, [gameUrl]);
 
   useEffect(() => {
-    if (pendingMatchupId && !gameUrl) {
-      const timer = setTimeout(() => {
-        LucraSDK.present({
+    console.log('[MiniGame] useEffect: pendingMatchupId=', pendingMatchupId, 'gameUrl=', gameUrl);
+    if (!pendingMatchupId || gameUrl) {
+      return;
+    }
+    console.log('[MiniGame] Will present matchup details in 500ms for:', pendingMatchupId);
+    const timer = setTimeout(async () => {
+      console.log('[MiniGame] Presenting matchup details for:', pendingMatchupId);
+      try {
+        await LucraSDK.present({
           name: LucraSDK.FLOW.GAMES_CONTEST_DETAILS,
           matchupId: pendingMatchupId,
         });
-        setPendingMatchupId(null);
-      }, 500);
-      return () => clearTimeout(timer);
-    }
+        console.log('[MiniGame] present() resolved');
+      } catch (e: any) {
+        console.log('[MiniGame] present() error:', e?.message || String(e));
+      }
+      setPendingMatchupId(null);
+    }, 1000);
+    return () => clearTimeout(timer);
   }, [pendingMatchupId, gameUrl]);
-
-  const webViewRef = useRef<WebView>(null);
-
-  const handleWebViewMessage = useCallback(
-    (event: WebViewMessageEvent) => {
-      let body: { type?: string; payload?: any };
-      try {
-        body = JSON.parse(event.nativeEvent.data);
-      } catch {
-        return;
-      }
-
-      const { type, payload } = body;
-      switch (type) {
-        case 'set_load_progress':
-          break;
-        case 'loaded':
-        case 'hide_loading_screen':
-          break;
-        case 'close_game':
-          closeGame();
-          break;
-        case 'haptic_feedback': {
-          const cleaned =
-            typeof payload === 'string' ? payload.replace(/"/g, '') : '';
-          triggerHaptic(cleaned);
-          break;
-        }
-        case 'log': {
-          if (payload && typeof payload === 'object') {
-            const logType = payload.LogType ?? 'Log';
-            const msg = payload.Message ?? '';
-            const stack = payload.StackTrace ?? '';
-            console.log(
-              `[MiniGame JS] [${logType}] ${msg}${stack ? ` | ${stack}` : ''}`
-            );
-          }
-          break;
-        }
-      }
-    },
-    [closeGame]
-  );
-
-  const INJECTED_JS = `
-    (function() {
-      window.addEventListener('message', function(e) {
-        window.ReactNativeWebView.postMessage(typeof e.data === 'string' ? e.data : JSON.stringify(e.data));
-      });
-      if (window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.skm) {
-        var orig = window.webkit.messageHandlers.skm.postMessage.bind(window.webkit.messageHandlers.skm);
-        window.webkit.messageHandlers.skm.postMessage = function(msg) {
-          window.ReactNativeWebView.postMessage(JSON.stringify(msg));
-          orig(msg);
-        };
-      }
-      true;
-    })();
-  `;
-
-  const gameModal = (
-    <Modal
-      visible={!!gameUrl}
-      animationType="slide"
-      presentationStyle="fullScreen"
-      statusBarTranslucent
-      supportedOrientations={['portrait', 'landscape']}
-    >
-      <StatusBar hidden />
-      <View style={Styles.fullScreen}>
-        <WebView
-          ref={webViewRef}
-          source={{ uri: gameUrl ?? '' }}
-          style={Styles.flex}
-          javaScriptEnabled
-          domStorageEnabled
-          allowsInlineMediaPlayback
-          mediaPlaybackRequiresUserAction={false}
-          onMessage={handleWebViewMessage}
-          injectedJavaScript={INJECTED_JS}
-        />
-        <TouchableOpacity
-          style={Styles.closeButton}
-          onPress={closeGame}
-        >
-          <Text style={Styles.closeIcon}>✕</Text>
-        </TouchableOpacity>
-      </View>
-    </Modal>
-  );
 
   return (
     <SafeAreaView className="flex-1 bg-indigo-900 pt-8">
-      {gameModal}
+      <MiniGameWebView url={gameUrl} onClose={closeGame} />
       <KeyboardAvoidingView
         style={Styles.flex}
         behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
@@ -353,26 +250,5 @@ const Styles = StyleSheet.create({
   },
   chevron: {
     tintColor: 'white',
-  },
-  fullScreen: {
-    flex: 1,
-    backgroundColor: '#000',
-  },
-  closeButton: {
-    position: 'absolute',
-    top: 50,
-    left: 16,
-    width: 36,
-    height: 36,
-    borderRadius: 18,
-    backgroundColor: 'rgba(0,0,0,0.6)',
-    alignItems: 'center',
-    justifyContent: 'center',
-    zIndex: 10,
-  },
-  closeIcon: {
-    color: '#fff',
-    fontSize: 18,
-    fontWeight: 'bold',
   },
 });

--- a/example/src/container/MiniGameLauncher.tsx
+++ b/example/src/container/MiniGameLauncher.tsx
@@ -110,15 +110,18 @@ export const MiniGameLauncher: React.FC<Props> = ({ navigation }) => {
     setGameUrl(null);
   }, []);
 
-  const handleModalDismiss = useCallback(() => {
-    if (pendingMatchupId) {
-      LucraSDK.present({
-        name: LucraSDK.FLOW.GAMES_CONTEST_DETAILS,
-        matchupId: pendingMatchupId,
-      });
-      setPendingMatchupId(null);
+  useEffect(() => {
+    if (pendingMatchupId && !gameUrl) {
+      const timer = setTimeout(() => {
+        LucraSDK.present({
+          name: LucraSDK.FLOW.GAMES_CONTEST_DETAILS,
+          matchupId: pendingMatchupId,
+        });
+        setPendingMatchupId(null);
+      }, 500);
+      return () => clearTimeout(timer);
     }
-  }, [pendingMatchupId]);
+  }, [pendingMatchupId, gameUrl]);
 
   const webViewRef = useRef<WebView>(null);
 
@@ -186,7 +189,6 @@ export const MiniGameLauncher: React.FC<Props> = ({ navigation }) => {
       presentationStyle="fullScreen"
       statusBarTranslucent
       supportedOrientations={['portrait', 'landscape']}
-      onDismiss={handleModalDismiss}
     >
       <StatusBar hidden />
       <View style={Styles.fullScreen}>

--- a/example/src/container/MiniGameLauncher.tsx
+++ b/example/src/container/MiniGameLauncher.tsx
@@ -35,27 +35,29 @@ const GAME_MODES = [
 ];
 
 function triggerHaptic(type: string) {
-  switch (type.toLowerCase()) {
-    case 'light':
-    case 'soft':
-    case 'tiny':
-    case 'selection':
-      Vibration.vibrate(10);
-      break;
-    case 'medium':
-    case 'success':
-      Vibration.vibrate(20);
-      break;
-    case 'heavy':
-    case 'rigid':
-    case 'failure':
-    case 'warning':
-      Vibration.vibrate(40);
-      break;
-    default:
-      Vibration.vibrate(10);
-      break;
-  }
+  try {
+    switch (type.toLowerCase()) {
+      case 'light':
+      case 'soft':
+      case 'tiny':
+      case 'selection':
+        Vibration.vibrate(10);
+        break;
+      case 'medium':
+      case 'success':
+        Vibration.vibrate(20);
+        break;
+      case 'heavy':
+      case 'rigid':
+      case 'failure':
+      case 'warning':
+        Vibration.vibrate(40);
+        break;
+      default:
+        Vibration.vibrate(10);
+        break;
+    }
+  } catch {}
 }
 
 export const MiniGameLauncher: React.FC<Props> = ({ navigation }) => {

--- a/example/src/container/MiniGameLauncher.tsx
+++ b/example/src/container/MiniGameLauncher.tsx
@@ -14,8 +14,10 @@ import {
   View,
   ActivityIndicator,
   Alert,
-  Vibration,
 } from 'react-native';
+import ReactNativeHapticFeedback, {
+  type HapticFeedbackTypes,
+} from 'react-native-haptic-feedback';
 import { WebView, type WebViewMessageEvent } from 'react-native-webview';
 import { Assets } from '../Assets';
 import type { RootStackParamList } from '../Routes';
@@ -34,29 +36,23 @@ const GAME_MODES = [
   { label: 'Tournament', value: MiniGameMode.TOURNAMENT },
 ];
 
+const HAPTIC_MAP: Record<string, HapticFeedbackTypes> = {
+  light: 'impactLight',
+  soft: 'soft',
+  tiny: 'impactLight',
+  selection: 'selection',
+  medium: 'impactMedium',
+  success: 'notificationSuccess',
+  heavy: 'impactHeavy',
+  rigid: 'rigid',
+  failure: 'notificationError',
+  warning: 'notificationWarning',
+};
+
 function triggerHaptic(type: string) {
   try {
-    switch (type.toLowerCase()) {
-      case 'light':
-      case 'soft':
-      case 'tiny':
-      case 'selection':
-        Vibration.vibrate(10);
-        break;
-      case 'medium':
-      case 'success':
-        Vibration.vibrate(20);
-        break;
-      case 'heavy':
-      case 'rigid':
-      case 'failure':
-      case 'warning':
-        Vibration.vibrate(40);
-        break;
-      default:
-        Vibration.vibrate(10);
-        break;
-    }
+    const key = type.toLowerCase();
+    ReactNativeHapticFeedback.trigger(HAPTIC_MAP[key] ?? 'impactLight');
   } catch {}
 }
 

--- a/example/src/container/MiniGameLauncher.tsx
+++ b/example/src/container/MiniGameLauncher.tsx
@@ -1,0 +1,374 @@
+import React, { useCallback, useRef, useState } from 'react';
+import {
+  Image,
+  KeyboardAvoidingView,
+  Modal,
+  Platform,
+  SafeAreaView,
+  ScrollView,
+  StatusBar,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+  ActivityIndicator,
+  Alert,
+  Vibration,
+} from 'react-native';
+import { WebView, type WebViewMessageEvent } from 'react-native-webview';
+import { Assets } from '../Assets';
+import type { RootStackParamList } from '../Routes';
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import {
+  LucraSDK,
+  MiniGameMode,
+} from '@lucra-sports/lucra-react-native-sdk';
+
+type Props = NativeStackScreenProps<RootStackParamList, 'MiniGameLauncher'>;
+
+const GAME_MODES = [
+  { label: 'Practice', value: MiniGameMode.PRACTICE },
+  { label: '1v1', value: MiniGameMode.ONE_VS_ONE },
+  { label: 'Free For All', value: MiniGameMode.FREE_FOR_ALL },
+  { label: 'Tournament', value: MiniGameMode.TOURNAMENT },
+];
+
+function triggerHaptic(type: string) {
+  switch (type.toLowerCase()) {
+    case 'light':
+    case 'soft':
+    case 'tiny':
+    case 'selection':
+      Vibration.vibrate(10);
+      break;
+    case 'medium':
+    case 'success':
+      Vibration.vibrate(20);
+      break;
+    case 'heavy':
+    case 'rigid':
+    case 'failure':
+    case 'warning':
+      Vibration.vibrate(40);
+      break;
+    default:
+      Vibration.vibrate(10);
+      break;
+  }
+}
+
+export const MiniGameLauncher: React.FC<Props> = ({ navigation }) => {
+  const [gameId, setGameId] = useState('');
+  const [gameMode, setGameMode] = useState<MiniGameMode>(
+    MiniGameMode.PRACTICE
+  );
+  const [amount, setAmount] = useState(0);
+  const [matchupId, setMatchupId] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [gameUrl, setGameUrl] = useState<string | null>(null);
+  const resultMatchupIdRef = useRef<string | null>(null);
+
+  const handleStartMiniGame = async () => {
+    if (!gameId.trim()) {
+      Alert.alert('Error', 'Please enter a Game ID');
+      return;
+    }
+    setLoading(true);
+    setGameUrl(null);
+    resultMatchupIdRef.current = null;
+    try {
+      const result = await LucraSDK.startMiniGame(
+        gameId.trim(),
+        gameMode,
+        gameMode === MiniGameMode.PRACTICE ? 0 : amount,
+        matchupId.trim() || undefined
+      );
+      resultMatchupIdRef.current = result.matchupId ?? null;
+      setGameUrl(result.url);
+    } catch (e: any) {
+      Alert.alert('Error', e?.message || String(e));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const [pendingMatchupId, setPendingMatchupId] = useState<string | null>(null);
+
+  const closeGame = useCallback(() => {
+    const returnedMatchupId = resultMatchupIdRef.current;
+    resultMatchupIdRef.current = null;
+    if (returnedMatchupId) {
+      setPendingMatchupId(returnedMatchupId);
+    }
+    setGameUrl(null);
+  }, []);
+
+  const handleModalDismiss = useCallback(() => {
+    if (pendingMatchupId) {
+      LucraSDK.present({
+        name: LucraSDK.FLOW.GAMES_CONTEST_DETAILS,
+        matchupId: pendingMatchupId,
+      });
+      setPendingMatchupId(null);
+    }
+  }, [pendingMatchupId]);
+
+  const webViewRef = useRef<WebView>(null);
+
+  const handleWebViewMessage = useCallback(
+    (event: WebViewMessageEvent) => {
+      let body: { type?: string; payload?: any };
+      try {
+        body = JSON.parse(event.nativeEvent.data);
+      } catch {
+        return;
+      }
+
+      const { type, payload } = body;
+      switch (type) {
+        case 'set_load_progress':
+          break;
+        case 'loaded':
+        case 'hide_loading_screen':
+          break;
+        case 'close_game':
+          closeGame();
+          break;
+        case 'haptic_feedback': {
+          const cleaned =
+            typeof payload === 'string' ? payload.replace(/"/g, '') : '';
+          triggerHaptic(cleaned);
+          break;
+        }
+        case 'log': {
+          if (payload && typeof payload === 'object') {
+            const logType = payload.LogType ?? 'Log';
+            const msg = payload.Message ?? '';
+            const stack = payload.StackTrace ?? '';
+            console.log(
+              `[MiniGame JS] [${logType}] ${msg}${stack ? ` | ${stack}` : ''}`
+            );
+          }
+          break;
+        }
+      }
+    },
+    [closeGame]
+  );
+
+  const INJECTED_JS = `
+    (function() {
+      window.addEventListener('message', function(e) {
+        window.ReactNativeWebView.postMessage(typeof e.data === 'string' ? e.data : JSON.stringify(e.data));
+      });
+      if (window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.skm) {
+        var orig = window.webkit.messageHandlers.skm.postMessage.bind(window.webkit.messageHandlers.skm);
+        window.webkit.messageHandlers.skm.postMessage = function(msg) {
+          window.ReactNativeWebView.postMessage(JSON.stringify(msg));
+          orig(msg);
+        };
+      }
+      true;
+    })();
+  `;
+
+  const gameModal = (
+    <Modal
+      visible={!!gameUrl}
+      animationType="slide"
+      presentationStyle="fullScreen"
+      statusBarTranslucent
+      supportedOrientations={['portrait', 'landscape']}
+      onDismiss={handleModalDismiss}
+    >
+      <StatusBar hidden />
+      <View style={Styles.fullScreen}>
+        <WebView
+          ref={webViewRef}
+          source={{ uri: gameUrl ?? '' }}
+          style={Styles.flex}
+          javaScriptEnabled
+          domStorageEnabled
+          allowsInlineMediaPlayback
+          mediaPlaybackRequiresUserAction={false}
+          onMessage={handleWebViewMessage}
+          injectedJavaScript={INJECTED_JS}
+        />
+        <TouchableOpacity
+          style={Styles.closeButton}
+          onPress={closeGame}
+        >
+          <Text style={Styles.closeIcon}>✕</Text>
+        </TouchableOpacity>
+      </View>
+    </Modal>
+  );
+
+  return (
+    <SafeAreaView className="flex-1 bg-indigo-900 pt-8">
+      {gameModal}
+      <KeyboardAvoidingView
+        style={Styles.flex}
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+        keyboardVerticalOffset={Platform.OS === 'ios' ? 16 : 0}
+      >
+        <ScrollView
+          contentContainerStyle={Styles.scrollContent}
+          keyboardShouldPersistTaps="handled"
+        >
+          <View className="pt-10 px-4 gap-4 pb-12">
+            <View className="flex-row items-center gap-2 pb-5">
+              <TouchableOpacity
+                onPress={() => navigation.goBack()}
+                style={Styles.backButton}
+              >
+                <Image
+                  source={Assets.ChevronLeft}
+                  style={Styles.chevron}
+                  className="h-8 w-8"
+                />
+              </TouchableOpacity>
+              <Text className="text-white text-lg font-bold ml-2">
+                Mini Game Launcher
+              </Text>
+            </View>
+
+            <View className="flex-row gap-2">
+              {['hoops-web', 'runaway-web', 'tappysoccer-web'].map((id) => (
+                <TouchableOpacity
+                  key={id}
+                  className={`flex-1 p-2 rounded-lg border ${
+                    gameId === id
+                      ? 'bg-indigo-500 border-indigo-300'
+                      : 'bg-indigo-700 border-indigo-500'
+                  }`}
+                  onPress={() => setGameId(id)}
+                >
+                  <Text className="text-white text-center text-xs">
+                    {id}
+                  </Text>
+                </TouchableOpacity>
+              ))}
+            </View>
+
+            <TextInput
+              value={gameId}
+              onChangeText={setGameId}
+              placeholder="Game ID (required)"
+              placeholderTextColor="#999"
+              autoCapitalize="none"
+              autoCorrect={false}
+              className="border border-indigo-400 p-4 rounded-lg text-white"
+            />
+
+            <Text className="text-white">Game Mode</Text>
+            <View className="flex-row flex-wrap gap-2">
+              {GAME_MODES.map((mode) => (
+                <TouchableOpacity
+                  key={mode.value}
+                  className={`flex-1 min-w-[70px] p-3 rounded-lg border ${
+                    gameMode === mode.value
+                      ? 'bg-indigo-500 border-indigo-300'
+                      : 'bg-indigo-700 border-indigo-500'
+                  }`}
+                  onPress={() => {
+                    setGameMode(mode.value);
+                    if (mode.value === MiniGameMode.PRACTICE) {
+                      setAmount(0);
+                    } else if (amount === 0) {
+                      setAmount(1);
+                    }
+                  }}
+                >
+                  <Text className="text-white text-center text-xs">
+                    {mode.label}
+                  </Text>
+                </TouchableOpacity>
+              ))}
+            </View>
+
+            {gameMode !== MiniGameMode.PRACTICE && (
+              <>
+                <Text className="text-white">Amount</Text>
+                <View className="flex-row gap-2">
+                  {[1, 5].map((val) => (
+                    <TouchableOpacity
+                      key={val}
+                      className={`flex-1 p-3 rounded-lg border ${
+                        amount === val
+                          ? 'bg-indigo-500 border-indigo-300'
+                          : 'bg-indigo-700 border-indigo-500'
+                      }`}
+                      onPress={() => setAmount(val)}
+                    >
+                      <Text className="text-white text-center">${val}</Text>
+                    </TouchableOpacity>
+                  ))}
+                </View>
+              </>
+            )}
+
+            <TextInput
+              value={matchupId}
+              onChangeText={setMatchupId}
+              placeholder="Matchup ID (optional)"
+              placeholderTextColor="#999"
+              className="border border-indigo-400 p-4 rounded-lg text-white"
+            />
+
+            <TouchableOpacity
+              className="w-full bg-green-600 p-4 items-center justify-center rounded-lg"
+              onPress={handleStartMiniGame}
+              disabled={loading}
+            >
+              {loading ? (
+                <ActivityIndicator color="white" />
+              ) : (
+                <Text className="font-bold text-white">Start Mini Game</Text>
+              )}
+            </TouchableOpacity>
+          </View>
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+};
+
+const Styles = StyleSheet.create({
+  flex: {
+    flex: 1,
+  },
+  scrollContent: {
+    flexGrow: 1,
+    paddingBottom: 24,
+  },
+  backButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  chevron: {
+    tintColor: 'white',
+  },
+  fullScreen: {
+    flex: 1,
+    backgroundColor: '#000',
+  },
+  closeButton: {
+    position: 'absolute',
+    top: 50,
+    left: 16,
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    backgroundColor: 'rgba(0,0,0,0.6)',
+    alignItems: 'center',
+    justifyContent: 'center',
+    zIndex: 10,
+  },
+  closeIcon: {
+    color: '#fff',
+    fontSize: 18,
+    fontWeight: 'bold',
+  },
+});

--- a/example/src/container/MiniGameLauncher.tsx
+++ b/example/src/container/MiniGameLauncher.tsx
@@ -39,9 +39,7 @@ export const MiniGameLauncher: React.FC<Props> = ({ navigation }) => {
   }, []);
 
   const [gameId, setGameId] = useState('');
-  const [gameMode, setGameMode] = useState<MiniGameMode>(
-    MiniGameMode.PRACTICE
-  );
+  const [gameMode, setGameMode] = useState<MiniGameMode>(MiniGameMode.PRACTICE);
   const [amount, setAmount] = useState(0);
   const [matchupId, setMatchupId] = useState('');
   const [loading, setLoading] = useState(false);
@@ -76,7 +74,12 @@ export const MiniGameLauncher: React.FC<Props> = ({ navigation }) => {
 
   const closeGame = useCallback(() => {
     const returnedMatchupId = resultMatchupIdRef.current;
-    console.log('[MiniGame] closeGame called, matchupId:', returnedMatchupId, 'gameUrl:', gameUrl);
+    console.log(
+      '[MiniGame] closeGame called, matchupId:',
+      returnedMatchupId,
+      'gameUrl:',
+      gameUrl
+    );
     resultMatchupIdRef.current = null;
     if (returnedMatchupId) {
       setPendingMatchupId(returnedMatchupId);
@@ -85,13 +88,24 @@ export const MiniGameLauncher: React.FC<Props> = ({ navigation }) => {
   }, [gameUrl]);
 
   useEffect(() => {
-    console.log('[MiniGame] useEffect: pendingMatchupId=', pendingMatchupId, 'gameUrl=', gameUrl);
+    console.log(
+      '[MiniGame] useEffect: pendingMatchupId=',
+      pendingMatchupId,
+      'gameUrl=',
+      gameUrl
+    );
     if (!pendingMatchupId || gameUrl) {
       return;
     }
-    console.log('[MiniGame] Will present matchup details in 500ms for:', pendingMatchupId);
+    console.log(
+      '[MiniGame] Will present matchup details in 500ms for:',
+      pendingMatchupId
+    );
     const timer = setTimeout(async () => {
-      console.log('[MiniGame] Presenting matchup details for:', pendingMatchupId);
+      console.log(
+        '[MiniGame] Presenting matchup details for:',
+        pendingMatchupId
+      );
       try {
         await LucraSDK.present({
           name: LucraSDK.FLOW.GAMES_CONTEST_DETAILS,
@@ -146,9 +160,7 @@ export const MiniGameLauncher: React.FC<Props> = ({ navigation }) => {
                   }`}
                   onPress={() => setGameId(id)}
                 >
-                  <Text className="text-white text-center text-xs">
-                    {id}
-                  </Text>
+                  <Text className="text-white text-center text-xs">{id}</Text>
                 </TouchableOpacity>
               ))}
             </View>

--- a/ios/LucraClient.mm
+++ b/ios/LucraClient.mm
@@ -44,6 +44,10 @@ RCT_EXPORT_METHOD(cancelGamesMatchup : (NSString *)matchupId resolve : (
   [swiftClient cancelGamesMatchup:matchupId resolve:resolve reject:reject];
 }
 
+RCT_EXPORT_METHOD(preloadGeoToken) {
+  [swiftClient preloadGeoToken];
+}
+
 RCT_EXPORT_METHOD(startMiniGame : (NSString *)gameId
                   gameMode : (NSString *)gameMode
                   amount : (double)amount

--- a/ios/LucraClient.mm
+++ b/ios/LucraClient.mm
@@ -44,6 +44,20 @@ RCT_EXPORT_METHOD(cancelGamesMatchup : (NSString *)matchupId resolve : (
   [swiftClient cancelGamesMatchup:matchupId resolve:resolve reject:reject];
 }
 
+RCT_EXPORT_METHOD(startMiniGame : (NSString *)gameId
+                  gameMode : (NSString *)gameMode
+                  amount : (double)amount
+                  matchupId : (NSString *)matchupId
+                  resolve : (RCTPromiseResolveBlock)resolve
+                  reject : (RCTPromiseRejectBlock)reject) {
+  [swiftClient startMiniGame:gameId
+                    gameMode:gameMode
+                      amount:amount
+                   matchupId:matchupId
+                     resolve:resolve
+                      reject:reject];
+}
+
 RCT_EXPORT_METHOD(configureUser : (NSDictionary *)user resolve : (
     RCTPromiseResolveBlock)resolve reject : (RCTPromiseRejectBlock)reject) {
   [swiftClient configureUser:user resolve:resolve reject:reject];

--- a/ios/LucraClient.mm
+++ b/ios/LucraClient.mm
@@ -44,8 +44,8 @@ RCT_EXPORT_METHOD(cancelGamesMatchup : (NSString *)matchupId resolve : (
   [swiftClient cancelGamesMatchup:matchupId resolve:resolve reject:reject];
 }
 
-RCT_EXPORT_METHOD(preloadGeoToken) {
-  [swiftClient preloadGeoToken];
+RCT_EXPORT_METHOD(preloadGeoToken : (NSString *)context) {
+  [swiftClient preloadGeoToken:context];
 }
 
 RCT_EXPORT_METHOD(startMiniGame : (NSString *)gameId

--- a/ios/LucraSwiftClient.swift
+++ b/ios/LucraSwiftClient.swift
@@ -413,6 +413,10 @@ private enum ErrorCode {
       }
     }
 
+    @objc public func preloadGeoToken() {
+      self.nativeClient.api.preloadGeoToken(context: .cashBuyIn)
+    }
+
     @objc public func startMiniGame(
       _ gameId: String,
       gameMode: String,

--- a/ios/LucraSwiftClient.swift
+++ b/ios/LucraSwiftClient.swift
@@ -413,8 +413,19 @@ private enum ErrorCode {
       }
     }
 
-    @objc public func preloadGeoToken() {
-      self.nativeClient.api.preloadGeoToken(context: .cashBuyIn)
+    @objc public func preloadGeoToken(_ context: String) {
+      let geoContext: GeoComplyContext
+      switch context.lowercased() {
+      case "freebuyin":
+        geoContext = .freeBuyIn
+      case "deposit":
+        geoContext = .deposit
+      case "withdrawal":
+        geoContext = .withdrawal
+      default:
+        geoContext = .cashBuyIn
+      }
+      self.nativeClient.api.preloadGeoToken(context: geoContext)
     }
 
     @objc public func startMiniGame(

--- a/ios/LucraSwiftClient.swift
+++ b/ios/LucraSwiftClient.swift
@@ -425,7 +425,9 @@ private enum ErrorCode {
       default:
         geoContext = .cashBuyIn
       }
-      self.nativeClient.api.preloadGeoToken(context: geoContext)
+      DispatchQueue.main.async {
+        self.nativeClient.api.preloadGeoToken(context: geoContext)
+      }
     }
 
     @objc public func startMiniGame(

--- a/ios/LucraSwiftClient.swift
+++ b/ios/LucraSwiftClient.swift
@@ -413,6 +413,53 @@ private enum ErrorCode {
       }
     }
 
+    @objc public func startMiniGame(
+      _ gameId: String,
+      gameMode: String,
+      amount: Double,
+      matchupId: String,
+      resolve: @escaping RCTPromiseResolveBlock,
+      reject: @escaping RCTPromiseRejectBlock
+    ) {
+      Task { @MainActor in
+        let parsedMode: MiniGameMode
+        switch gameMode.lowercased() {
+        case "practice":
+          parsedMode = .practice
+        case "1v1":
+          parsedMode = .oneVsOne
+        case "free_for_all":
+          parsedMode = .freeForAll
+        case "tournament":
+          parsedMode = .tournament
+        default:
+          reject("invalidGameMode", "Invalid MiniGameMode: \(gameMode)", nil)
+          return
+        }
+
+        let optionalMatchupId: String? = matchupId.isEmpty ? nil : matchupId
+
+        let result = await self.nativeClient.api.startMiniGame(
+          gameId: gameId,
+          gameMode: parsedMode,
+          amount: Decimal(amount),
+          matchupId: optionalMatchupId,
+          onProgress: nil
+        )
+
+        switch result {
+        case .success(let session):
+          resolve([
+            "url": session.iframeURL.absoluteString,
+            "sessionId": session.sessionId,
+            "matchupId": session.matchupId as Any
+          ])
+        case .failure(let error):
+          rejectLucraError(reject, error: error)
+        }
+      }
+    }
+
     private func rejectLucraError(_ reject: RCTPromiseRejectBlock, error: Error) {
       let code: String
       let message: String

--- a/lucra-react-native-sdk.podspec
+++ b/lucra-react-native-sdk.podspec
@@ -39,7 +39,7 @@ Pod::Spec.new do |s|
     s.dependency 'Auth0'
   else
     s.source = { :git => "https://github.com/Lucra-Sports/lucra-react-native-sdk", :tag => "#{s.version}" }
-    s.dependency 'LucraSDK', '5.1.0'
+    s.dependency 'LucraSDK', '5.3.0'
   end
   
   if fabric_enabled

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lucra-sports/lucra-react-native-sdk",
-  "version": "0.0.0",
+  "version": "5.3.0",
   "description": "Lucra React Native SDK",
   "main": "lib/module/index.js",
   "types": "./lib/typescript/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -84,8 +84,10 @@
     "react-native": "0.79.2",
     "react-native-builder-bob": "^0.40.11",
     "react-native-css-interop": "^0.1.20",
+    "react-native-haptic-feedback": "^3.0.0",
     "react-native-reanimated": "^3.17.5",
     "react-native-safe-area-context": "^4.12.0",
+    "react-native-webview": "^13.12.0",
     "typescript": "^5.8.3"
   },
   "jest": {
@@ -106,7 +108,9 @@
   },
   "peerDependencies": {
     "react": "*",
-    "react-native": "*"
+    "react-native": "*",
+    "react-native-haptic-feedback": ">=2.0.0",
+    "react-native-webview": ">=13.0.0"
   },
   "engines": {
     "node": ">= 20.0.0"

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "react-native-haptic-feedback": "^3.0.0",
     "react-native-reanimated": "^3.17.5",
     "react-native-safe-area-context": "^4.12.0",
-    "react-native-webview": "^13.12.0",
+    "react-native-webview": "^13.14.0",
     "typescript": "^5.8.3"
   },
   "jest": {

--- a/src/MiniGameWebView.tsx
+++ b/src/MiniGameWebView.tsx
@@ -85,7 +85,10 @@ export const MiniGameWebView: React.FC<MiniGameWebViewProps> = ({
         case 'hide_loading_screen':
           break;
         case 'close_game':
-          console.log('[MiniGameWebView] close_game received, didClose:', didClose.current);
+          console.log(
+            '[MiniGameWebView] close_game received, didClose:',
+            didClose.current
+          );
           if (!didClose.current) {
             didClose.current = true;
             onClose();

--- a/src/MiniGameWebView.tsx
+++ b/src/MiniGameWebView.tsx
@@ -1,0 +1,171 @@
+import React, { useCallback, useEffect, useRef } from 'react';
+import {
+  Modal,
+  StatusBar,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import ReactNativeHapticFeedback, {
+  HapticFeedbackTypes,
+} from 'react-native-haptic-feedback';
+import { WebView, type WebViewMessageEvent } from 'react-native-webview';
+
+const HAPTIC_MAP: Record<string, HapticFeedbackTypes> = {
+  light: HapticFeedbackTypes.impactLight,
+  soft: HapticFeedbackTypes.soft,
+  tiny: HapticFeedbackTypes.impactLight,
+  selection: HapticFeedbackTypes.selection,
+  medium: HapticFeedbackTypes.impactMedium,
+  success: HapticFeedbackTypes.notificationSuccess,
+  heavy: HapticFeedbackTypes.impactHeavy,
+  rigid: HapticFeedbackTypes.rigid,
+  failure: HapticFeedbackTypes.notificationError,
+  warning: HapticFeedbackTypes.notificationWarning,
+};
+
+function triggerHaptic(type: string) {
+  try {
+    const key = type.toLowerCase();
+    ReactNativeHapticFeedback.trigger(
+      HAPTIC_MAP[key] ?? HapticFeedbackTypes.impactLight
+    );
+  } catch {}
+}
+
+const INJECTED_JS = `
+  (function() {
+    window.addEventListener('message', function(e) {
+      window.ReactNativeWebView.postMessage(typeof e.data === 'string' ? e.data : JSON.stringify(e.data));
+    });
+    if (window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.skm) {
+      var orig = window.webkit.messageHandlers.skm.postMessage.bind(window.webkit.messageHandlers.skm);
+      window.webkit.messageHandlers.skm.postMessage = function(msg) {
+        window.ReactNativeWebView.postMessage(JSON.stringify(msg));
+        orig(msg);
+      };
+    }
+    true;
+  })();
+`;
+
+type MiniGameWebViewProps = {
+  url: string | null;
+  onClose: () => void;
+};
+
+export const MiniGameWebView: React.FC<MiniGameWebViewProps> = ({
+  url,
+  onClose,
+}) => {
+  const webViewRef = useRef<WebView>(null);
+  const didClose = useRef(false);
+
+  useEffect(() => {
+    if (url) {
+      didClose.current = false;
+    }
+  }, [url]);
+
+  const handleWebViewMessage = useCallback(
+    (event: WebViewMessageEvent) => {
+      let body: { type?: string; payload?: any };
+      try {
+        body = JSON.parse(event.nativeEvent.data);
+      } catch {
+        return;
+      }
+
+      const { type, payload } = body;
+      switch (type) {
+        case 'set_load_progress':
+          break;
+        case 'loaded':
+        case 'hide_loading_screen':
+          break;
+        case 'close_game':
+          console.log('[MiniGameWebView] close_game received, didClose:', didClose.current);
+          if (!didClose.current) {
+            didClose.current = true;
+            onClose();
+          }
+          break;
+        case 'haptic_feedback': {
+          const cleaned =
+            typeof payload === 'string' ? payload.replace(/"/g, '') : '';
+          triggerHaptic(cleaned);
+          break;
+        }
+        case 'log': {
+          if (payload && typeof payload === 'object') {
+            const logType = payload.LogType ?? 'Log';
+            const msg = payload.Message ?? '';
+            const stack = payload.StackTrace ?? '';
+            console.log(
+              `[MiniGame JS] [${logType}] ${msg}${stack ? ` | ${stack}` : ''}`
+            );
+          }
+          break;
+        }
+      }
+    },
+    [onClose]
+  );
+
+  return (
+    <Modal
+      visible={!!url}
+      animationType="slide"
+      presentationStyle="fullScreen"
+      statusBarTranslucent
+      supportedOrientations={['portrait']}
+    >
+      <StatusBar hidden />
+      <View style={Styles.fullScreen}>
+        <WebView
+          ref={webViewRef}
+          source={{ uri: url ?? '' }}
+          style={Styles.webView}
+          javaScriptEnabled
+          domStorageEnabled
+          allowsInlineMediaPlayback
+          mediaPlaybackRequiresUserAction={false}
+          onMessage={handleWebViewMessage}
+          injectedJavaScript={INJECTED_JS}
+        />
+        <TouchableOpacity style={Styles.closeButton} onPress={onClose}>
+          <Text style={Styles.closeIcon}>✕</Text>
+        </TouchableOpacity>
+      </View>
+    </Modal>
+  );
+};
+
+const Styles = StyleSheet.create({
+  webView: {
+    flex: 1,
+    backgroundColor: '#000',
+  },
+  fullScreen: {
+    flex: 1,
+    backgroundColor: '#000',
+  },
+  closeButton: {
+    position: 'absolute',
+    top: 50,
+    left: 16,
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    backgroundColor: 'rgba(0,0,0,0.6)',
+    alignItems: 'center',
+    justifyContent: 'center',
+    zIndex: 10,
+  },
+  closeIcon: {
+    color: '#fff',
+    fontSize: 18,
+    fontWeight: 'bold',
+  },
+});

--- a/src/NativeLucraClient.ts
+++ b/src/NativeLucraClient.ts
@@ -31,6 +31,7 @@ interface Spec extends TurboModule {
   cancelGamesMatchup(matchupId: string): Promise<void>;
 
   // Mini Games
+  preloadGeoToken: () => void;
   startMiniGame(
     gameId: string,
     gameMode: string,

--- a/src/NativeLucraClient.ts
+++ b/src/NativeLucraClient.ts
@@ -31,7 +31,7 @@ interface Spec extends TurboModule {
   cancelGamesMatchup(matchupId: string): Promise<void>;
 
   // Mini Games
-  preloadGeoToken: () => void;
+  preloadGeoToken: (context: string) => void;
   startMiniGame(
     gameId: string,
     gameMode: string,

--- a/src/NativeLucraClient.ts
+++ b/src/NativeLucraClient.ts
@@ -30,6 +30,14 @@ interface Spec extends TurboModule {
   acceptFreeForAllRecreationalGame(matchupId: string): Promise<void>;
   cancelGamesMatchup(matchupId: string): Promise<void>;
 
+  // Mini Games
+  startMiniGame(
+    gameId: string,
+    gameMode: string,
+    amount: number,
+    matchupId: string
+  ): Promise<Object>;
+
   // Pool tournaments
   // https://docs.lucrasports.com/lucra-sdk/DPHUTeEoFi2Jw8eLoOMk/integration-documents/pool-tournaments
   getRecommendedTournaments: (params: Object) => Promise<Object[]>;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -621,6 +621,9 @@ export const LucraSDK = {
   cancelGamesMatchup: (gameId: string): Promise<void> => {
     return LucraClient.cancelGamesMatchup(gameId);
   },
+  preloadGeoToken: (): void => {
+    LucraClient.preloadGeoToken();
+  },
   startMiniGame: async (
     gameId: string,
     gameMode: MiniGameMode,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import LucraClient from './NativeLucraClient';
 export { default as LucraFlowView } from './LucraFlowViewNativeComponent';
+export { MiniGameWebView } from './MiniGameWebView';
 import { default as LucraProfilePillNative } from './LucraProfilePillNativeComponent';
 import { default as LucraCreateContestButtonNative } from './LucraCreateContestButtonNativeComponent';
 import {
@@ -104,6 +105,13 @@ if (LucraClient == null) {
   throw new Error(
     'Native LucraSDK is not found. You can try clearing your build cache and try again.'
   );
+}
+
+export enum GeoComplyContext {
+  FREE_BUY_IN = 'freeBuyIn',
+  CASH_BUY_IN = 'cashBuyIn',
+  DEPOSIT = 'deposit',
+  WITHDRAWAL = 'withdrawal',
 }
 
 export enum MiniGameMode {
@@ -621,8 +629,8 @@ export const LucraSDK = {
   cancelGamesMatchup: (gameId: string): Promise<void> => {
     return LucraClient.cancelGamesMatchup(gameId);
   },
-  preloadGeoToken: (): void => {
-    LucraClient.preloadGeoToken();
+  preloadGeoToken: (context: GeoComplyContext): void => {
+    LucraClient.preloadGeoToken(context);
   },
   startMiniGame: async (
     gameId: string,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -445,7 +445,7 @@ function present(params: {
   locationId?: string;
 }): Promise<void> {
   try {
-    return Promise.resolve(LucraClient.present(params));
+    return LucraClient.present(params);
   } catch (error) {
     return Promise.reject(error);
   }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -106,6 +106,19 @@ if (LucraClient == null) {
   );
 }
 
+export enum MiniGameMode {
+  PRACTICE = 'practice',
+  ONE_VS_ONE = '1v1',
+  FREE_FOR_ALL = 'free_for_all',
+  TOURNAMENT = 'tournament',
+}
+
+export type StartMiniGameResult = {
+  url: string;
+  sessionId: string;
+  matchupId?: string;
+};
+
 export enum LucraEnvironment {
   PRODUCTION = 'production',
   STAGING = 'staging',
@@ -607,6 +620,19 @@ export const LucraSDK = {
   },
   cancelGamesMatchup: (gameId: string): Promise<void> => {
     return LucraClient.cancelGamesMatchup(gameId);
+  },
+  startMiniGame: async (
+    gameId: string,
+    gameMode: MiniGameMode,
+    amount: number = 0,
+    matchupId?: string
+  ): Promise<StartMiniGameResult> => {
+    return (await LucraClient.startMiniGame(
+      gameId,
+      gameMode,
+      amount,
+      matchupId ?? ''
+    )) as StartMiniGameResult;
   },
   getMatchup: async (matchupId: string): Promise<MatchupInfo> => {
     return (await LucraClient.getMatchup(matchupId)) as MatchupInfo;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2655,7 +2655,7 @@ __metadata:
     react-native-haptic-feedback: ^3.0.0
     react-native-reanimated: ^3.17.5
     react-native-safe-area-context: ^4.12.0
-    react-native-webview: ^13.12.0
+    react-native-webview: ^13.14.0
     typescript: ^5.8.3
   peerDependencies:
     react: "*"
@@ -6202,7 +6202,7 @@ __metadata:
     react-native-safe-area-context: ^5.4.0
     react-native-screens: ^4.10.0
     react-native-vector-icons: ^10.2.0
-    react-native-webview: ^13.12.0
+    react-native-webview: ^13.14.0
     reanimated-color-picker: ^4.0.1
     tailwindcss: ^3.4.14
   languageName: unknown
@@ -10751,7 +10751,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-webview@npm:^13.12.0":
+"react-native-webview@npm:^13.14.0":
   version: 13.16.1
   resolution: "react-native-webview@npm:13.16.1"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -6197,6 +6197,7 @@ __metadata:
     react-native-safe-area-context: ^5.4.0
     react-native-screens: ^4.10.0
     react-native-vector-icons: ^10.2.0
+    react-native-webview: ^13.12.0
     reanimated-color-picker: ^4.0.1
     tailwindcss: ^3.4.14
   languageName: unknown
@@ -7230,7 +7231,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"invariant@npm:^2.2.4":
+"invariant@npm:2.2.4, invariant@npm:^2.2.4":
   version: 2.2.4
   resolution: "invariant@npm:2.2.4"
   dependencies:
@@ -10729,6 +10730,19 @@ __metadata:
     fa6-upgrade: bin/fa6-upgrade.sh
     generate-icon: bin/generate-icon.js
   checksum: fda930df4e63f12533268f5b339ebe4c77c691eae43503328466b3087ed868a06a4593fd246e75ac6b5ec955543eec35608c7922191bdcc3b3a94ed7f3575ef0
+  languageName: node
+  linkType: hard
+
+"react-native-webview@npm:^13.12.0":
+  version: 13.16.1
+  resolution: "react-native-webview@npm:13.16.1"
+  dependencies:
+    escape-string-regexp: ^4.0.0
+    invariant: 2.2.4
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+  checksum: c202500df090114877d7a92549dbac1c36bdcc2010d50ddffb57aedcec81870d9695f1e4e3ef852cbe02a8ef952ef8626b120b774813c396a32b4fdc5838a4a5
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2652,12 +2652,16 @@ __metadata:
     react-native: 0.79.2
     react-native-builder-bob: ^0.40.11
     react-native-css-interop: ^0.1.20
+    react-native-haptic-feedback: ^3.0.0
     react-native-reanimated: ^3.17.5
     react-native-safe-area-context: ^4.12.0
+    react-native-webview: ^13.12.0
     typescript: ^5.8.3
   peerDependencies:
     react: "*"
     react-native: "*"
+    react-native-haptic-feedback: ">=2.0.0"
+    react-native-webview: ">=13.0.0"
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6193,6 +6193,7 @@ __metadata:
     react-native: ^0.79.2
     react-native-date-picker: ^5.0.12
     react-native-gesture-handler: ^2.25.0
+    react-native-haptic-feedback: ^3.0.0
     react-native-permissions: ^5.0.2
     react-native-safe-area-context: ^5.4.0
     react-native-screens: ^4.10.0
@@ -10624,6 +10625,19 @@ __metadata:
     react: "*"
     react-native: "*"
   checksum: 51b155bcc56043b9e06bf8ded089c44348e8da297b38e73f203f2d6ce8bd51698f85a38dca8eeab3d2ab721aeddefc270acd99e16cf493b20f1f429ad02214b8
+  languageName: node
+  linkType: hard
+
+"react-native-haptic-feedback@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "react-native-haptic-feedback@npm:3.0.0"
+  peerDependencies:
+    react: ">=18.0.0"
+    react-native: ">=0.71.0"
+  peerDependenciesMeta:
+    react:
+      optional: true
+  checksum: 9fca6abeb5463edd3ee00812b11af211a9161a14beeb900b78d9cf3244d28c8c9952c682cbb3a8c4fe42bd9d490dc4372ff7be84bda0af7bcf6b14b12818d4c4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
…droid 6.4.0

- Bridge startMiniGame through TurboModule spec, public API, iOS (ObjC + Swift), and Android (Kotlin)
- Add MiniGameMode enum and StartMiniGameResult type
- Add MiniGameLauncher sample app screen with WebView, postMessage handlers, and haptic feedback
- Present matchup details flow after game close when matchupId is returned
- Bump package version to 5.3.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mini Games support: launch Practice, 1v1, Free‑for‑all, and Tournament modes; returns session info (url, sessionId, optional matchupId). Public APIs: preload geo token and start mini‑game. Example app: Mini Game launcher with full‑screen WebView, messaging, close handling, loading states, and haptic feedback.

* **Chores**
  * Bumped package and iOS SDK versions; Android Gradle now resolves snapshot SDK artifacts. Added webview dependency and vibration permission to the example app.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Lucra-Sports/lucra-react-native-sdk/pull/127)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->