### PR TITLE
LS-2436: Enhance getMatchup and add subscription

### DIFF
--- a/android/src/main/kotlin/com/lucrasdk/Libs/LucraMapper.kt
+++ b/android/src/main/kotlin/com/lucrasdk/Libs/LucraMapper.kt
@@ -8,9 +8,13 @@ import com.lucrasdk.Libs.LucraUtils.Companion.convertReadableMapToStringMap
 import com.lucrasdk.Libs.LucraUtils.Companion.convertStringMapToWritableMap
 import com.lucrasports.LucraUser
 import com.lucrasports.matchup.ParticipantGroupOutcome
+import com.lucrasports.matchup.RecreationalGame
+import com.lucrasports.matchup.TopLevelMatchupSubType
 import com.lucrasports.matchup.TournamentLeaderboard
 import com.lucrasports.matchup.sports_impl.SportsInterval
 import com.lucrasports.sdk.core.contest.LucraMatchup
+import com.lucrasports.sdk.core.contest.LucraMatchupDetails
+import com.lucrasports.sdk.core.contest.MatchupSubtype
 import com.lucrasports.sdk.core.contest.tournament.CatalogReward
 import com.lucrasports.sdk.core.contest.tournament.Participant
 import com.lucrasports.sdk.core.contest.tournament.PayoutReward
@@ -386,8 +390,23 @@ object LucraMapper {
         map.putString("createdAt", match.createdAt)
         map.putString("creatorId", match.creatorId)
         map.putString("status", match.status.rawValue)
-        map.putString("subtype", match.subtype.name)
-        map.putString("type", match.type.name)
+        // Emit the backend's canonical raw values so both platforms return the
+        // same strings (iOS maps these from String-backed enum raw values).
+        map.putString(
+            "subtype", when (match.subtype) {
+                MatchupSubtype.GroupVsGroup -> "GROUP_VS_GROUP"
+                MatchupSubtype.FreeForAll -> "FREE_FOR_ALL"
+            }
+        )
+        map.putString(
+            "type", when (match.type) {
+                TopLevelMatchupSubType.ProfessionalSportsPlayerStat -> "PROFESSIONAL_SPORTS_PLAYER_STAT"
+                TopLevelMatchupSubType.ProfessionalSportsTeamStat -> "PROFESSIONAL_SPORTS_TEAM_STAT"
+                TopLevelMatchupSubType.PoolTournament -> "POOL_TOURNAMENT"
+                is RecreationalGame -> "RECREATIONAL_GAME"
+                else -> "UNKNOWN"
+            }
+        )
         map.putBoolean("isPublic", match.isPublic)
 
         match.creator?.let { map.putMap("creator", userToMap(it)) }
@@ -486,6 +505,59 @@ object LucraMapper {
 
             map.putMap("recreationGameExtension", extMap)
         }
+
+        return map
+    }
+
+    fun lucraMatchupDetailsToMap(details: LucraMatchupDetails): WritableMap {
+        val map = Arguments.createMap()
+        map.putMap("matchup", lucraMatchupToMap(details.matchup))
+
+        val groupsArray = Arguments.createArray()
+        details.groups.forEach { group ->
+            val groupMap = Arguments.createMap()
+            groupMap.putString("id", group.id)
+            group.name?.let { groupMap.putString("name", it) }
+            groupMap.putString(
+                "outcome", when (group.outcome) {
+                    ParticipantGroupOutcome.Loss -> "LOSS"
+                    ParticipantGroupOutcome.Tie -> "TIE"
+                    ParticipantGroupOutcome.Win -> "WIN"
+                    else -> "UNKNOWN"
+                }
+            )
+            group.score?.let { groupMap.putDouble("score", it) }
+
+            val participantsArray = Arguments.createArray()
+            group.participants.forEach { participant ->
+                val participantMap = Arguments.createMap()
+                participantMap.putString("userId", participant.userId)
+                participantMap.putString("username", participant.username)
+                participant.avatarUrl?.let { participantMap.putString("avatarUrl", it) }
+                participant.individualPayout?.let {
+                    participantMap.putDouble("individualPayout", it)
+                }
+                participantsArray.pushMap(participantMap)
+            }
+            groupMap.putArray("participants", participantsArray)
+
+            groupsArray.pushMap(groupMap)
+        }
+        map.putArray("groups", groupsArray)
+
+        val scoresArray = Arguments.createArray()
+        details.participantScores.forEach { score ->
+            val scoreMap = Arguments.createMap()
+            score.userId?.let { scoreMap.putString("userId", it) }
+            score.username?.let { scoreMap.putString("username", it) }
+            score.avatarUrl?.let { scoreMap.putString("avatarUrl", it) }
+            score.place?.let { scoreMap.putInt("place", it) }
+            score.score?.let { scoreMap.putDouble("score", it) }
+            score.finishedAt?.let { scoreMap.putString("finishedAt", it) }
+            score.groupId?.let { scoreMap.putString("groupId", it) }
+            scoresArray.pushMap(scoreMap)
+        }
+        map.putArray("participantScores", scoresArray)
 
         return map
     }

--- a/android/src/main/kotlin/com/lucrasdk/LucraClientModule.kt
+++ b/android/src/main/kotlin/com/lucrasdk/LucraClientModule.kt
@@ -714,34 +714,75 @@ class LucraClientModule(private val context: ReactApplicationContext) :
 
     @ReactMethod
     fun getMatchup(matchupId: String, promise: Promise) {
-        LucraClient().getMatchup(matchupId) { result ->
+        // The native one-shot getMatchup runs an unauthenticated query that skips
+        // participant groups server-side; getMatchupDetails fetches the same
+        // matchup with groups populated, so resolve from its inner matchup.
+        LucraClient().getMatchupDetails(matchupId) { result ->
             when (result) {
-                is GameInteractions.GetMatchupResult.Failure -> {
-                    val (code, message) = when (val failure = result.failure) {
-                        is GameInteractions.FailedRetrieveMatchup.APIError -> ErrorCodes.API_ERROR to failure.message.ifNullOrBlank { "API error occurred" }
-                        is GameInteractions.FailedRetrieveMatchup.LocationError -> ErrorCodes.LOCATION_ERROR to failure.message.ifNullOrBlank { "Location error occurred" }
-                    }
-                    promise.reject(code, message)
-                }
+                is GameInteractions.GetMatchupDetailsResult.Failure ->
+                    rejectLucraError(promise, result.error)
 
-                is GameInteractions.GetMatchupResult.Success -> {
-                    val res = LucraMapper.lucraMatchupToMap(result.matchup)
-                    promise.resolve(res)
-                }
+                is GameInteractions.GetMatchupDetailsResult.Success ->
+                    promise.resolve(LucraMapper.lucraMatchupToMap(result.details.matchup))
             }
         }
     }
 
-    private fun rejectLucraError(promise: Promise, error: LucraError) {
-        val (code, message) = when (error) {
-            is APIError -> ErrorCodes.API_ERROR to (error.message.ifNullOrBlank { "API error occurred" })
-            is LocationError -> ErrorCodes.LOCATION_ERROR to (error.message.ifNullOrBlank { "Location error occurred" })
-            UserStateError.InsufficientFunds -> ErrorCodes.INSUFFICIENT_FUNDS to "User has insufficient funds"
-            UserStateError.NotAllowed -> ErrorCodes.NOT_ALLOWED to "User is not allowed to perform such operation"
-            UserStateError.NotInitialized -> ErrorCodes.NOT_INITIALIZED to "User has not been initialized"
-            UserStateError.Unverified -> ErrorCodes.UNVERIFIED to "User has not been verified"
-            else -> ErrorCodes.UNKNOWN_ERROR to (error.toString().ifNullOrBlank { "Unknown error occurred" })
+    @ReactMethod
+    fun getMatchupDetails(matchupId: String, promise: Promise) {
+        LucraClient().getMatchupDetails(matchupId) { result ->
+            when (result) {
+                is GameInteractions.GetMatchupDetailsResult.Failure ->
+                    rejectLucraError(promise, result.error)
+
+                is GameInteractions.GetMatchupDetailsResult.Success ->
+                    promise.resolve(LucraMapper.lucraMatchupDetailsToMap(result.details))
+            }
         }
+    }
+
+    @ReactMethod
+    fun subscribeMatchupDetails(matchupId: String) {
+        // subscribe = true keeps firing onResult as the matchup changes on the
+        // server (live GYP scores / auto settlement). Results are forwarded to
+        // JS through the `matchupDetails` event.
+        LucraClient().getMatchupDetails(matchupId, subscribe = true) { result ->
+            val params = Arguments.createMap().apply {
+                putString("matchupId", matchupId)
+                when (result) {
+                    is GameInteractions.GetMatchupDetailsResult.Success ->
+                        putMap("details", LucraMapper.lucraMatchupDetailsToMap(result.details))
+
+                    is GameInteractions.GetMatchupDetailsResult.Failure -> {
+                        val (code, message) = lucraErrorCodeMessage(result.error)
+                        putMap("error", Arguments.createMap().apply {
+                            putString("code", code)
+                            putString("message", message)
+                        })
+                    }
+                }
+            }
+            sendEvent(context, "matchupDetails", params)
+        }
+    }
+
+    @ReactMethod
+    fun cancelMatchupDetailsSubscription() {
+        LucraClient().cancelMatchupSubscription()
+    }
+
+    private fun lucraErrorCodeMessage(error: LucraError): Pair<String, String> = when (error) {
+        is APIError -> ErrorCodes.API_ERROR to (error.message.ifNullOrBlank { "API error occurred" })
+        is LocationError -> ErrorCodes.LOCATION_ERROR to (error.message.ifNullOrBlank { "Location error occurred" })
+        UserStateError.InsufficientFunds -> ErrorCodes.INSUFFICIENT_FUNDS to "User has insufficient funds"
+        UserStateError.NotAllowed -> ErrorCodes.NOT_ALLOWED to "User is not allowed to perform such operation"
+        UserStateError.NotInitialized -> ErrorCodes.NOT_INITIALIZED to "User has not been initialized"
+        UserStateError.Unverified -> ErrorCodes.UNVERIFIED to "User has not been verified"
+        else -> ErrorCodes.UNKNOWN_ERROR to (error.toString().ifNullOrBlank { "Unknown error occurred" })
+    }
+
+    private fun rejectLucraError(promise: Promise, error: LucraError) {
+        val (code, message) = lucraErrorCodeMessage(error)
         promise.reject(code, message)
     }
 

--- a/docs/2.3_gyp_headless_functions.md
+++ b/docs/2.3_gyp_headless_functions.md
@@ -150,8 +150,16 @@ Parameters:
 
 Returns: `MatchupInfo` (includes participants, teams, status, and `recreationGameExtension` with game/buy-in details where available).
 
+`status`, `type`, and `subtype` are returned as the backend's canonical raw values on both platforms — see the `MatchupStatus`, `MatchupType`, and `MatchupSubtype` TypeScript types for the full lists.
+
+If you also need group scores, individual payouts, or per-participant ranking scores (e.g. for automated score tracking / auto settlement), use [Get Matchup Details](#get-matchup-details) instead.
+
 Errors that can be thrown:
 
+- `notInitialized`
+- `unverified`
+- `notAllowed`
+- `missingDemographicInformation`
 - `locationError`
 - `apiError`
 - `unknown` / `unknownError`
@@ -162,8 +170,8 @@ Example response:
 {
   "id": "matchup-id",
   "status": "OPEN",
-  "type": "GAMES",
-  "subtype": "RECREATIONAL",
+  "type": "RECREATIONAL_GAME",
+  "subtype": "GROUP_VS_GROUP",
   "isPublic": true,
   "createdAt": "2024-01-01T00:00:00Z",
   "updatedAt": "2024-01-01T00:00:00Z",
@@ -209,3 +217,172 @@ Example response:
   }
 }
 ```
+
+## Get Matchup Details
+
+The same matchup details call Lucra's native apps use to render a matchup: it returns the core matchup plus participant groups with aggregate scores and outcomes, individual payouts, and per-participant ranking scores from automated score tracking (GYP auto settlement).
+
+```ts
+const details = await LucraSDK.getMatchupDetails('MATCHUP_ID');
+```
+
+Parameters:
+- `matchupId` (string): Lucra matchup identifier.
+
+Returns: `MatchupDetails`
+- `matchup` (`MatchupInfo`): Core matchup object — same shape as `getMatchup`.
+- `groups` (`MatchupGroupDetails[]`): Participant groups. Empty groups are included (e.g. the second team in a team-vs-team matchup before anyone joins).
+  - `id` (string), `name` (string?), `outcome` (`'WIN' | 'LOSS' | 'TIE' | 'UNKNOWN'`)
+  - `score` (number?): Aggregate group score. Available for automated score-tracking matchups.
+  - `participants` (`MatchupParticipantDetails[]`): `userId`, `username`, `avatarUrl?`, and `individualPayout?` (payout after take rate and team split).
+- `participantScores` (`MatchupParticipantScore[]`): Per-participant ranking scores. Populated for automated score-tracking matchups only.
+  - `userId?`, `username?`, `avatarUrl?`, `place?` (final rank), `score?`, `finishedAt?` (ISO timestamp), `groupId?`
+
+Errors that can be thrown:
+
+- `notInitialized`
+- `unverified`
+- `notAllowed`
+- `missingDemographicInformation`
+- `locationError`
+- `apiError`
+- `unknown` / `unknownError`
+
+Example response:
+
+```json
+{
+  "matchup": {
+    "id": "matchup-id",
+    "status": "CLOSED",
+    "type": "RECREATIONAL_GAME",
+    "subtype": "FREE_FOR_ALL",
+    "isPublic": true,
+    "createdAt": "2024-01-01T00:00:00Z",
+    "updatedAt": "2024-01-01T00:10:00Z",
+    "creatorId": "user-123",
+    "winningGroupId": "group-a",
+    "participantGroups": [],
+    "recreationGameExtension": {
+      "gameId": "GAME_TYPE_ID",
+      "buyInAmount": 10
+    }
+  },
+  "groups": [
+    {
+      "id": "group-a",
+      "name": "alice",
+      "outcome": "WIN",
+      "score": 99.5,
+      "participants": [
+        {
+          "userId": "user-123",
+          "username": "alice",
+          "avatarUrl": null,
+          "individualPayout": 18
+        }
+      ]
+    },
+    {
+      "id": "group-b",
+      "name": "bob",
+      "outcome": "LOSS",
+      "score": 42,
+      "participants": [
+        {
+          "userId": "user-456",
+          "username": "bob",
+          "avatarUrl": null,
+          "individualPayout": 0
+        }
+      ]
+    }
+  ],
+  "participantScores": [
+    {
+      "userId": "user-123",
+      "username": "alice",
+      "avatarUrl": null,
+      "place": 1,
+      "score": 99.5,
+      "finishedAt": "2024-01-01T00:09:30Z",
+      "groupId": "group-a"
+    },
+    {
+      "userId": "user-456",
+      "username": "bob",
+      "avatarUrl": null,
+      "place": 2,
+      "score": 42,
+      "finishedAt": "2024-01-01T00:09:45Z",
+      "groupId": "group-b"
+    }
+  ]
+}
+```
+
+## Subscribe to Matchup Details (live)
+
+`getMatchupDetails` above is a one-shot fetch. To receive live updates as a matchup changes on the server — the same stream Lucra's native apps use to render scores updating and auto settlement landing in real time — use the `useMatchupDetails` hook, or `subscribeToMatchupDetails` outside of React components.
+
+### `useMatchupDetails` hook (recommended)
+
+The hook scopes the subscription to the component lifecycle — it subscribes on mount (and whenever `matchupId` changes) and cancels the native subscription automatically on unmount, so it cannot leak:
+
+```tsx
+import { useMatchupDetails } from '@lucra-sports/lucra-react-native-sdk';
+
+function MatchupScreen({ matchupId }: { matchupId: string }) {
+  const { details, error } = useMatchupDetails(matchupId);
+
+  if (error) return <Text>{error.message}</Text>;
+  if (!details) return <Text>Loading…</Text>;
+
+  return (
+    <>
+      <Text>Status: {details.matchup.status}</Text>
+      {details.participantScores.map((s) => (
+        <Text key={s.userId}>
+          #{s.place} {s.username}: {s.score}
+        </Text>
+      ))}
+    </>
+  );
+}
+```
+
+- `details` is `null` until the first update arrives, and resets when `matchupId` changes.
+- `error.code` matches the error codes listed under [Get Matchup Details](#get-matchup-details).
+- Pass `undefined` as the id to stay idle (e.g. while the matchup id is still loading).
+
+### `subscribeToMatchupDetails` (manual)
+
+For non-component code (or custom lifecycles), the manual API returns an `unsubscribe` function:
+
+```ts
+const unsubscribe = LucraSDK.subscribeToMatchupDetails(
+  'MATCHUP_ID',
+  (details) => {
+    // Fires immediately with the current details, then again on every change.
+    console.log('status', details.matchup.status);
+  },
+  (error) => {
+    // Optional. `error.code` matches the error codes listed above.
+    console.warn('matchup details error', error.code, error.message);
+  }
+);
+
+// Later — stop receiving updates and cancel the native subscription:
+unsubscribe();
+```
+
+Parameters:
+- `matchupId` (string): Lucra matchup identifier.
+- `onResult` (`(details: MatchupDetails) => void`): Called immediately with the current `MatchupDetails` (same shape as `getMatchupDetails`) and again on every server-side change.
+- `onError` (`(error: { code: string; message: string }) => void`, optional): Called when the native subscription emits a failure.
+
+Returns: an `unsubscribe` function. Call it to stop receiving updates and cancel the native subscription.
+
+Notes:
+- Only one matchup-details subscription is active at a time (a native SDK constraint). Calling `subscribeToMatchupDetails` again — for the same or a different matchup — replaces the previous subscription.
+- The returned `unsubscribe` is safe to call more than once, and a stale `unsubscribe` (e.g. from a screen that unmounted after another screen subscribed) never cancels the newer subscription.

--- a/docs/4.3_syw_headless_functions.md
+++ b/docs/4.3_syw_headless_functions.md
@@ -15,6 +15,8 @@ Parameters:
 
 Returns: `MatchupInfo`
 
+`status`, `type`, and `subtype` are returned as the backend's canonical raw values on both platforms — see the `MatchupStatus`, `MatchupType`, and `MatchupSubtype` TypeScript types for the full lists.
+
 Example response:
 
 ```json
@@ -24,8 +26,8 @@ Example response:
   "updatedAt": "2024-01-01T00:00:00Z",
   "creatorId": "user-123",
   "status": "OPEN",
-  "subtype": "SPORTS",
-  "type": "SPORTS",
+  "subtype": "GROUP_VS_GROUP",
+  "type": "PROFESSIONAL_SPORTS_PLAYER_STAT",
   "isPublic": true,
   "winningGroupId": null,
   "creator": {

--- a/docs/SDK_RELEASE_NOTES.md
+++ b/docs/SDK_RELEASE_NOTES.md
@@ -1,3 +1,20 @@
+# UPCOMING
+* Added the `LucraSDK.getMatchupDetails(matchupId)` function to retrieve detailed matchup information, including
+  participant groups with scores and outcomes, and individual payouts.
+  See [GYP headless functions](2.3_gyp_headless_functions.md#get-matchup-details).
+* Added `LucraSDK.subscribeToMatchupDetails(matchupId, onResult, onError?)` to receive live updates when matchup details
+  change. The callback fires immediately and whenever scores update or settlement occurs. Returns an `unsubscribe`
+  function to cancel the subscription.
+  See [Subscribe to Matchup Details](2.3_gyp_headless_functions.md#subscribe-to-matchup-details-live).
+* Added the `useMatchupDetails(matchupId)` React hook for subscribing to matchup details within a component.
+  Automatically unsubscribes when the component unmounts.
+* `getMatchup` cross-platform parity fixes:
+  * iOS: `status`, `type`, and `subtype` are now returned (previously dropped — Swift enums were not serializable across the bridge).
+  * iOS: `tournamentLeaderboard` is no longer attached as a placeholder to participants of non-tournament matchups, and `place`/`placeOverride` are numbers (previously strings).
+  * iOS: `socialConnectionId` now maps the actual field instead of repeating the user `id`.
+  * Android: `participantGroups` is no longer empty (the underlying one-shot query skipped groups for unauthenticated requests; the matchup now resolves through the details query).
+  * Breaking (Android): `type` and `subtype` now return canonical raw values matching iOS and the `MatchupType`/`MatchupSubtype` TypeScript unions — e.g. `RECREATIONAL_GAME` instead of `RecreationalGame`, `GROUP_VS_GROUP` instead of `GroupVsGroup`.
+
 # 5.5.0
 * Bumped iOS to [5.5.0](https://github.com/Lucra-Sports/lucra-ios-sdk/releases/tag/5.5.0)
 * Bumped Android to [6.6.0](https://github.com/Lucra-Sports/lucra-android-sdk/releases/tag/6.6.0)

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -101,10 +101,10 @@ PODS:
   - hermes-engine/Pre-built (0.79.2)
   - JWTDecode (3.3.0)
   - lucra-react-native-sdk (5.5.0):
-    - Auth0
     - DoubleConversion
     - glog
     - hermes-engine
+    - LucraSDK (= 5.5.0)
     - RCT-Folly (= 2024.11.18.00)
     - RCTRequired
     - RCTTypeSafety
@@ -125,6 +125,8 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
+  - LucraSDK (5.5.0):
+    - Auth0
   - nanopb (3.30910.0):
     - nanopb/decode (= 3.30910.0)
     - nanopb/encode (= 3.30910.0)
@@ -2214,6 +2216,7 @@ SPEC REPOS:
     - GoogleAppMeasurement
     - GoogleUtilities
     - JWTDecode
+    - LucraSDK
     - nanopb
     - PromisesObjC
     - SimpleKeychain
@@ -2416,7 +2419,8 @@ SPEC CHECKSUMS:
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
   hermes-engine: 314be5250afa5692b57b4dd1705959e1973a8ebe
   JWTDecode: 1ca6f765844457d0dd8690436860fecee788f631
-  lucra-react-native-sdk: 4342c9be66817aad1beb49b0589a6933ba46a19c
+  lucra-react-native-sdk: 4b7a8572afa80a3ac9f74badfbbe673be47aa08d
+  LucraSDK: bd3c23378edf22807cc88ed1d4d9b218546d28f0
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   RCT-Folly: e78785aa9ba2ed998ea4151e314036f6c49e6d82
@@ -2482,7 +2486,7 @@ SPEC CHECKSUMS:
   React-timing: beb0ba912f9ffc1a6758afa767ae5c03302dc9ee
   React-utils: 4b32801a05eff845d316edd59b313a3e25c5fc08
   ReactAppDependencyProvider: 04d5eb15eb46be6720e17a4a7fa92940a776e584
-  ReactCodegen: bc41fa2ca7be8239f9d7cba538dfb0443a537da6
+  ReactCodegen: 041559ba76d00f6680dfa0916b3c791f4babe5ea
   ReactCommon: 1511ef100f1afa4c199fe52fe7a8d2529a41429a
   Resolver: 89e3fa61be7350b5faa3cb45cef11c2d9f6a7b2b
   RNCAsyncStorage: 646c1bf2ebfc78d6632a3b0399f471fba8101e73
@@ -2501,4 +2505,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 057413d3ec6fc9cc94d5ef21a76854377931b31f
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2

--- a/example/src/container/Api.container.tsx
+++ b/example/src/container/Api.container.tsx
@@ -23,6 +23,79 @@ import Clipboard from '@react-native-clipboard/clipboard';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'APIFlow'>;
 
+// iOS serializes dictionaries in random key order while Android preserves
+// insertion order — sort keys so responses diff cleanly across platforms.
+const sortKeysDeep = (value: unknown): unknown => {
+  if (Array.isArray(value)) {
+    return value.map(sortKeysDeep);
+  }
+  if (value !== null && typeof value === 'object') {
+    return Object.keys(value as Record<string, unknown>)
+      .sort()
+      .reduce<Record<string, unknown>>((acc, key) => {
+        acc[key] = sortKeysDeep((value as Record<string, unknown>)[key]);
+        return acc;
+      }, {});
+  }
+  return value;
+};
+
+// Matches, in priority order: an object key ("foo":), a string value,
+// a number, a boolean, or null — so each can be colorized independently.
+const JSON_TOKEN_REGEX =
+  /("(?:\\.|[^"\\])*"\s*:)|("(?:\\.|[^"\\])*")|(-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)|(true|false)|(null)/g;
+
+/** Renders pretty-printed JSON with lightweight syntax highlighting. */
+const HighlightedJson: React.FC<{ json: string }> = ({ json }) => {
+  const nodes: React.ReactNode[] = [];
+  let lastIndex = 0;
+  let key = 0;
+  let match: RegExpExecArray | null;
+  JSON_TOKEN_REGEX.lastIndex = 0;
+
+  while ((match = JSON_TOKEN_REGEX.exec(json)) !== null) {
+    if (match.index > lastIndex) {
+      nodes.push(
+        <Text key={key++} style={Styles.jsonPunctuation}>
+          {json.slice(lastIndex, match.index)}
+        </Text>
+      );
+    }
+
+    const [token] = match;
+    const style = match[1]
+      ? Styles.jsonKey
+      : match[2]
+        ? Styles.jsonString
+        : match[3]
+          ? Styles.jsonNumber
+          : match[4]
+            ? Styles.jsonBoolean
+            : Styles.jsonNull;
+
+    nodes.push(
+      <Text key={key++} style={style}>
+        {token}
+      </Text>
+    );
+    lastIndex = match.index + token.length;
+  }
+
+  if (lastIndex < json.length) {
+    nodes.push(
+      <Text key={key++} style={Styles.jsonPunctuation}>
+        {json.slice(lastIndex)}
+      </Text>
+    );
+  }
+
+  return (
+    <Text selectable style={Styles.codeText}>
+      {nodes}
+    </Text>
+  );
+};
+
 function handleLucraSDKError(e: LucraSDKError) {
   switch (e.code) {
     case 'notInitialized':
@@ -66,6 +139,31 @@ export const ApiContainer: React.FC<Props> = ({ navigation }) => {
     PoolTournament[]
   >([]);
   const [fullMatchupInfo, setFullMatchupInfo] = React.useState('');
+  const [resultTitle, setResultTitle] = React.useState('Result');
+  const [copied, setCopied] = React.useState(false);
+  const [isSubscribed, setIsSubscribed] = React.useState(false);
+  const unsubscribeRef = React.useRef<(() => void) | null>(null);
+
+  const showResult = React.useCallback((title: string, data: unknown) => {
+    setResultTitle(title);
+    setFullMatchupInfo(JSON.stringify(sortKeysDeep(data), null, 2));
+    setCopied(false);
+  }, []);
+
+  const stopSubscription = React.useCallback(() => {
+    unsubscribeRef.current?.();
+    unsubscribeRef.current = null;
+    setIsSubscribed(false);
+  }, []);
+
+  // Always tear down the live subscription when leaving the screen.
+  React.useEffect(() => stopSubscription, [stopSubscription]);
+
+  const copyResult = React.useCallback(() => {
+    Clipboard.setString(fullMatchupInfo);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  }, [fullMatchupInfo]);
 
   return (
     <SafeAreaView className="h-full bg-indigo-900  pt-8">
@@ -140,8 +238,7 @@ export const ApiContainer: React.FC<Props> = ({ navigation }) => {
             }
             try {
               const fullMatchup = await LucraSDK.getMatchup(matchupId);
-              const prettyJson = JSON.stringify(fullMatchup, null, 2);
-              setFullMatchupInfo(prettyJson);
+              showResult('Matchup', fullMatchup);
             } catch (e) {
               setFullMatchupInfo('');
               Alert.alert('Error', String(e));
@@ -151,23 +248,96 @@ export const ApiContainer: React.FC<Props> = ({ navigation }) => {
           <Text className="text-white">Get Matchup</Text>
         </TouchableOpacity>
 
+        <TouchableOpacity
+          className="w-full border border-indigo-400 bg-indigo-700 p-4 items-center justify-center rounded-lg"
+          onPress={async () => {
+            if (!matchupId) {
+              Alert.alert('Error', 'Please enter a Matchup ID');
+              return;
+            }
+            try {
+              const matchupDetails =
+                await LucraSDK.getMatchupDetails(matchupId);
+              showResult('Matchup Details', matchupDetails);
+            } catch (e) {
+              setFullMatchupInfo('');
+              Alert.alert('Error', String(e));
+            }
+          }}
+        >
+          <Text className="text-white">Get Matchup Details</Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          className="w-full border border-indigo-400 p-4 items-center justify-center rounded-lg"
+          style={isSubscribed ? Styles.copiedButton : Styles.actionButton}
+          onPress={() => {
+            if (isSubscribed) {
+              stopSubscription();
+              return;
+            }
+            if (!matchupId) {
+              Alert.alert('Error', 'Please enter a Matchup ID');
+              return;
+            }
+            unsubscribeRef.current = LucraSDK.subscribeToMatchupDetails(
+              matchupId,
+              (details) => showResult('Matchup Details (live)', details),
+              (error) =>
+                Alert.alert(
+                  'Subscription error',
+                  `${error.code}: ${error.message}`
+                )
+            );
+            setIsSubscribed(true);
+          }}
+        >
+          <Text className="text-white">
+            {isSubscribed
+              ? '● Unsubscribe (live)'
+              : 'Subscribe to Matchup Details'}
+          </Text>
+        </TouchableOpacity>
+
         {fullMatchupInfo ? (
-          <View className="w-full bg-gray-900 border border-indigo-400 rounded-lg mt-2 p-2">
-            <View className="flex-row justify-between items-center mb-2">
-              <Text className="text-indigo-300 font-bold">
-                Full Matchup JSON
-              </Text>
-              <TouchableOpacity
-                onPress={() => Clipboard.setString(fullMatchupInfo)}
-                className="px-2 py-1 bg-indigo-700 rounded"
-              >
-                <Text className="text-white text-xs">Copy</Text>
-              </TouchableOpacity>
+          <View
+            className="w-full border border-indigo-400 rounded-xl mt-2 overflow-hidden"
+            style={Styles.jsonCard}
+          >
+            <View
+              className="flex-row justify-between items-center px-3 py-2 border-b border-indigo-400"
+              style={Styles.jsonHeader}
+            >
+              <Text className="text-white font-bold">{resultTitle}</Text>
+              <View className="flex-row gap-2">
+                <TouchableOpacity
+                  onPress={copyResult}
+                  className="px-3 py-1 rounded"
+                  style={copied ? Styles.copiedButton : Styles.actionButton}
+                >
+                  <Text className="text-white text-xs font-semibold">
+                    {copied ? '✓ Copied' : 'Copy'}
+                  </Text>
+                </TouchableOpacity>
+                <TouchableOpacity
+                  onPress={() => setFullMatchupInfo('')}
+                  className="px-3 py-1 rounded"
+                  style={Styles.actionButton}
+                >
+                  <Text className="text-white text-xs font-semibold">
+                    Clear
+                  </Text>
+                </TouchableOpacity>
+              </View>
             </View>
-            <ScrollView horizontal>
-              <Text selectable style={Styles.codeText}>
-                {fullMatchupInfo}
-              </Text>
+            <ScrollView
+              style={Styles.jsonScroll}
+              nestedScrollEnabled
+              contentContainerClassName="p-3"
+            >
+              <ScrollView horizontal nestedScrollEnabled>
+                <HighlightedJson json={fullMatchupInfo} />
+              </ScrollView>
             </ScrollView>
           </View>
         ) : null}
@@ -252,7 +422,7 @@ export const ApiContainer: React.FC<Props> = ({ navigation }) => {
           onPress={async () => {
             try {
               let tournament = await LucraSDK.tournamentMatchup(tournamentId);
-              Alert.alert('Tournament', JSON.stringify(tournament, null, 2));
+              showResult('Tournament', tournament);
             } catch (e) {
               console.error(e);
             }
@@ -311,7 +481,41 @@ const Styles = StyleSheet.create({
   },
   codeText: {
     fontFamily: 'Menlo',
-    color: '#fff',
+    color: '#e2e8f0',
     fontSize: 12,
+    lineHeight: 18,
+  },
+  jsonCard: {
+    backgroundColor: '#020617',
+  },
+  jsonHeader: {
+    backgroundColor: '#3730a3',
+  },
+  jsonScroll: {
+    maxHeight: 360,
+  },
+  actionButton: {
+    backgroundColor: '#4f46e5',
+  },
+  copiedButton: {
+    backgroundColor: '#16a34a',
+  },
+  jsonKey: {
+    color: '#7dd3fc',
+  },
+  jsonString: {
+    color: '#86efac',
+  },
+  jsonNumber: {
+    color: '#fdba74',
+  },
+  jsonBoolean: {
+    color: '#c4b5fd',
+  },
+  jsonNull: {
+    color: '#94a3b8',
+  },
+  jsonPunctuation: {
+    color: '#e2e8f0',
   },
 });

--- a/ios/Extensions/LucraSwiftClient.extension.swift
+++ b/ios/Extensions/LucraSwiftClient.extension.swift
@@ -14,6 +14,7 @@ extension LucraSwiftClient {
     case tournamentJoined
     case tournamentsAutoJoined
     case miniGameFinished
+    case matchupDetails
     case _availableRewards
     case _claimReward
     case _viewRewards

--- a/ios/Libs/LucraMapper.swift
+++ b/ios/Libs/LucraMapper.swift
@@ -4,7 +4,7 @@ import LucraSDK
 public func userToMap(_ user: LucraSDK.LucraUser) -> [String: Any] {
   return [
     "id": user.id,
-    "socialConnectionId": user.id,
+    "socialConnectionId": user.socialConnectionId as Any,
     "username": user.username,
     "avatarUrl": user.avatarURL as Any,
     "loyaltyPoints": user.loyaltyPoints,
@@ -144,9 +144,11 @@ public func lucraMatchupToMap(match: LucraSDK.LucraMatchup) -> [String: Any] {
         "createdAt": match.createdAt.ISO8601Format(),
         "updatedAt": match.updatedAt.ISO8601Format(),
         "creatorId": match.creatorId,
-        "status": match.status,
-        "subtype": match.subtype,
-        "type": match.type,
+        // Swift enums are not bridgeable to [String: Any]; pass the raw value or the
+        // field is silently dropped from the resolved JS object.
+        "status": match.status == .unknown ? "UNKNOWN" : match.status.rawValue,
+        "subtype": match.subtype == .unknown ? "UNKNOWN" : match.subtype.rawValue,
+        "type": match.type == .unknown ? "UNKNOWN" : match.type.rawValue,
         "isPublic": match.isPublic,
         "creator": userToMap(match.creator)
     ]
@@ -170,8 +172,14 @@ public func lucraMatchupToMap(match: LucraSDK.LucraMatchup) -> [String: Any] {
                 "wager": participant.wager ?? 0.0,
                 "user": userToMap(participant.user)
             ]
-            
-            participantMap["tournamentLeaderboard"] = tournamentLeaderboardToMap(match.tournamentDetails, participant: participant)
+
+            // Only tournaments have leaderboard data; omit it elsewhere instead
+            // of emitting a placeholder (parity with Android). Checking the
+            // type, not tournamentDetails — the SDK populates tournamentDetails
+            // with an empty object even for non-tournament matchups.
+            if match.type == .tournament {
+                participantMap["tournamentLeaderboard"] = tournamentLeaderboardToMap(match.tournamentDetails, participant: participant)
+            }
 
             if let reward = participant.tenantReward {
                 participantMap["reward"] = rewardToMap(reward: reward)
@@ -254,6 +262,77 @@ public func lucraMatchupToMap(match: LucraSDK.LucraMatchup) -> [String: Any] {
 }
 
 
+public func lucraMatchupDetailsToMap(details: LucraSDK.LucraMatchupDetails) -> [String: Any] {
+    var map: [String: Any] = [
+        "matchup": lucraMatchupToMap(match: details.matchup)
+    ]
+
+    map["groups"] = details.groups.map { group in
+        var groupMap: [String: Any] = [
+            "id": group.id,
+            "outcome": {
+                switch group.outcome {
+                case .loss: return "LOSS"
+                case .tie: return "TIE"
+                case .win: return "WIN"
+                default: return "UNKNOWN"
+                }
+            }()
+        ]
+
+        if let name = group.name {
+            groupMap["name"] = name
+        }
+        if let score = group.score {
+            groupMap["score"] = score
+        }
+
+        groupMap["participants"] = group.participants.map { participant in
+            var participantMap: [String: Any] = [
+                "userId": participant.userId,
+                "username": participant.username
+            ]
+            if let avatarUrl = participant.avatarUrl {
+                participantMap["avatarUrl"] = avatarUrl
+            }
+            if let individualPayout = participant.individualPayout {
+                participantMap["individualPayout"] = Double(truncating: individualPayout as NSNumber)
+            }
+            return participantMap
+        }
+
+        return groupMap
+    }
+
+    map["participantScores"] = details.participantScores.map { score in
+        var scoreMap: [String: Any] = [:]
+        if let userId = score.userId {
+            scoreMap["userId"] = userId
+        }
+        if let username = score.username {
+            scoreMap["username"] = username
+        }
+        if let avatarUrl = score.avatarUrl {
+            scoreMap["avatarUrl"] = avatarUrl
+        }
+        if let place = score.place {
+            scoreMap["place"] = place
+        }
+        if let scoreValue = score.score {
+            scoreMap["score"] = scoreValue
+        }
+        if let finishedAt = score.finishedAt {
+            scoreMap["finishedAt"] = finishedAt.ISO8601Format()
+        }
+        if let groupId = score.groupId {
+            scoreMap["groupId"] = groupId
+        }
+        return scoreMap
+    }
+
+    return map
+}
+
 private func rewardToMap(reward: LucraSDK.LucraReward) -> [String: Any?] {
     let map: [String: Any?] = [
         "rewardId": reward.rewardId,
@@ -315,8 +394,8 @@ public func tournamentLeaderboardToMap(_ tournament: LucraSDK.TournamentsMatchup
     
     map["title"] = tournament?.title
     map["userScore"] = "" // Score is an internal only value
-    map["place"] = "\(tournamentParticipant?.place ?? 0)"
-    map["placeOverride"] = "\(tournamentParticipant?.place ?? 0)"
+    map["place"] = place
+    map["placeOverride"] = place
     map["rewardValue"] = tournamentParticipant?.rewardValue ?? 0.0
     map["rewardTierValue"] = tournament?.rewardStructure.first(where: { $0.position == Double(tournamentParticipant?.place ?? 0) })?.value ?? 0.0
     map["participantGroupId"] = tournamentParticipant?.id

--- a/ios/LucraClient.mm
+++ b/ios/LucraClient.mm
@@ -141,6 +141,22 @@ RCT_EXPORT_METHOD(getMatchup : (NSString *)matchupId
                    reject:reject];
 }
 
+RCT_EXPORT_METHOD(getMatchupDetails : (NSString *)matchupId
+                  resolve : (RCTPromiseResolveBlock)resolve
+                  reject : (RCTPromiseRejectBlock)reject) {
+  [swiftClient getMatchupDetails:matchupId
+                         resolve:resolve
+                          reject:reject];
+}
+
+RCT_EXPORT_METHOD(subscribeMatchupDetails : (NSString *)matchupId) {
+  [swiftClient subscribeMatchupDetails:matchupId];
+}
+
+RCT_EXPORT_METHOD(cancelMatchupDetailsSubscription) {
+  [swiftClient cancelMatchupDetailsSubscription];
+}
+
 RCT_EXPORT_METHOD(present : (NSDictionary *)params
                   resolve : (RCTPromiseResolveBlock)resolve
                    reject : (RCTPromiseRejectBlock)reject) {

--- a/ios/LucraSwiftClient.swift
+++ b/ios/LucraSwiftClient.swift
@@ -427,6 +427,60 @@ private enum ErrorCode {
       }
     }
 
+    @objc public func getMatchupDetails(
+      _ matchupId: String,
+      resolve: @escaping RCTPromiseResolveBlock,
+      reject: @escaping RCTPromiseRejectBlock
+    ) {
+      Task { @MainActor in
+        // Annotated to pick the one-shot async overload over the AsyncStream one.
+        let result: Result<LucraMatchupDetails, GamesMatchupError> =
+          await self.nativeClient.api.getMatchupDetails(matchupId: matchupId)
+
+        switch result {
+        case .success(let details):
+          resolve(lucraMatchupDetailsToMap(details: details))
+        case .failure(let error):
+          rejectLucraError(reject, error: error)
+        }
+      }
+    }
+
+    @objc public func subscribeMatchupDetails(_ matchupId: String) {
+      Task { @MainActor in
+        // The AsyncStream overload fires immediately and again on every
+        // server-side change; cancelMatchupDetailsSubscription() finishes it.
+        let stream: AsyncStream<Result<LucraMatchupDetails, GamesMatchupError>> =
+          self.nativeClient.api.getMatchupDetails(matchupId: matchupId)
+
+        for await result in stream {
+          switch result {
+          case .success(let details):
+            self.delegate?.sendEvent(
+              name: "matchupDetails",
+              result: [
+                "matchupId": matchupId,
+                "details": lucraMatchupDetailsToMap(details: details)
+              ])
+          case .failure(let error):
+            let (code, message) = self.lucraErrorCodeMessage(error)
+            self.delegate?.sendEvent(
+              name: "matchupDetails",
+              result: [
+                "matchupId": matchupId,
+                "error": ["code": code, "message": message]
+              ])
+          }
+        }
+      }
+    }
+
+    @objc public func cancelMatchupDetailsSubscription() {
+      Task { @MainActor in
+        self.nativeClient.api.cancelMatchupDetailsSubscription()
+      }
+    }
+
     @objc public func preloadGeoToken(_ context: String) {
       let tokenType: MiniGameGeoTokenType
       switch context.lowercased() {
@@ -609,6 +663,11 @@ private enum ErrorCode {
     }
 
     private func rejectLucraError(_ reject: RCTPromiseRejectBlock, error: Error) {
+      let (code, message) = lucraErrorCodeMessage(error)
+      reject(code, message, error)
+    }
+
+    private func lucraErrorCodeMessage(_ error: Error) -> (code: String, message: String) {
       let code: String
       let message: String
 
@@ -711,7 +770,7 @@ private enum ErrorCode {
         message = extractMessage(from: error)
       }
 
-      reject(code, message, error)
+      return (code, message)
     }
 
     private func extractMessage(from error: Error) -> String {

--- a/src/NativeLucraClient.ts
+++ b/src/NativeLucraClient.ts
@@ -14,6 +14,11 @@ interface Spec extends TurboModule {
 
   // All types of matchups
   getMatchup(matchupId: string): Promise<Object>;
+  getMatchupDetails(matchupId: string): Promise<Object>;
+  // Live matchup-details subscription — results arrive via the `matchupDetails`
+  // event; cancel ends the native subscription.
+  subscribeMatchupDetails(matchupId: string): void;
+  cancelMatchupDetailsSubscription(): void;
 
   // Games related
   createRecreationalGame(

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -185,14 +185,44 @@ export type LucraSDKParams = {
   merchantID?: string;
 };
 
+export type MatchupStatus =
+  | 'OPEN'
+  | 'CONFIRMED'
+  | 'LOCKED'
+  | 'CLOSED'
+  | 'CLOSED_TIE'
+  | 'PENDING_OUTCOMES'
+  | 'DISPUTE'
+  | 'CANCELED_BY_OWNER'
+  | 'CANCELED_DISPUTE'
+  | 'CANCELED_GAME_CANCELED'
+  | 'CANCELED_NOT_ACCEPTED'
+  | 'CANCELED_PLAYER_INACTIVE'
+  | 'CANCELED_THROUGH_API'
+  | 'CANCELED_TIMEOUT'
+  | 'UNKNOWN';
+
+export type MatchupType =
+  | 'RECREATIONAL_GAME'
+  | 'PROFESSIONAL_SPORTS_PLAYER_STAT'
+  | 'PROFESSIONAL_SPORTS_TEAM_STAT'
+  | 'POOL_TOURNAMENT'
+  | 'UNKNOWN';
+
+export type MatchupSubtype =
+  | 'GROUP_VS_GROUP'
+  | 'FREE_FOR_ALL'
+  | 'POOL_N_WINNER'
+  | 'UNKNOWN';
+
 export type MatchupInfo = {
   id: string;
   updatedAt: string;
   createdAt: string;
   creatorId: string;
-  status: string;
-  subtype: string;
-  type: string;
+  status: MatchupStatus;
+  subtype: MatchupSubtype;
+  type: MatchupType;
   isPublic: boolean;
   creator?: MatchupUserInfo;
   participantGroups: MatchupTeamInfo[];
@@ -223,6 +253,37 @@ export type MatchupUserInfo = {
   username: string;
   avatarUrl?: string;
   loyaltyPoints: number;
+};
+
+export type MatchupDetails = {
+  matchup: MatchupInfo;
+  groups: MatchupGroupDetails[];
+  participantScores: MatchupParticipantScore[];
+};
+
+export type MatchupGroupDetails = {
+  id: string;
+  name?: string;
+  outcome: 'WIN' | 'LOSS' | 'TIE' | 'UNKNOWN';
+  score?: number;
+  participants: MatchupParticipantDetails[];
+};
+
+export type MatchupParticipantDetails = {
+  userId: string;
+  username: string;
+  avatarUrl?: string;
+  individualPayout?: number;
+};
+
+export type MatchupParticipantScore = {
+  userId?: string;
+  username?: string;
+  avatarUrl?: string;
+  place?: number;
+  score?: number;
+  finishedAt?: string;
+  groupId?: string;
 };
 
 export type MatchupTeamInfo = {
@@ -405,6 +466,8 @@ let viewRewardsCallback: (() => void) | null = null;
 let viewRewardsSubscription: NativeEventSubscription;
 let lucraFlowDismissedSubscription: NativeEventSubscription;
 let lucraFlowDismissedCallback: ((flow: string) => void) | null = null;
+let matchupDetailsListener: NativeEventSubscription | null = null;
+let matchupDetailsGeneration = 0;
 
 type LucraContestListeners = {
   onGamesMatchupCreated?: (id: string) => void;
@@ -749,6 +812,55 @@ export const LucraSDK = {
   getMatchup: async (matchupId: string): Promise<MatchupInfo> => {
     return (await LucraClient.getMatchup(matchupId)) as MatchupInfo;
   },
+  getMatchupDetails: async (matchupId: string): Promise<MatchupDetails> => {
+    return (await LucraClient.getMatchupDetails(matchupId)) as MatchupDetails;
+  },
+  /**
+   * Subscribe to live matchup detail updates (e.g. GYP scores / auto
+   * settlement as a game progresses). `onResult` fires immediately with the
+   * current details and again on every server-side change.
+   *
+   * In React components prefer the `useMatchupDetails` hook, which scopes the
+   * subscription to the component lifecycle automatically.
+   *
+   * Returns an unsubscribe function — call it to stop receiving updates and
+   * cancel the native subscription. Only one matchup-details subscription is
+   * active at a time; subscribing again replaces the previous one. The
+   * returned function is safe to call more than once, and a stale unsubscribe
+   * never cancels a subscription that has since replaced it.
+   */
+  subscribeToMatchupDetails: (
+    matchupId: string,
+    onResult: (details: MatchupDetails) => void,
+    onError?: (error: { code: string; message: string }) => void
+  ): (() => void) => {
+    matchupDetailsListener?.remove();
+    const generation = ++matchupDetailsGeneration;
+    const subscription = eventEmitter.addListener(
+      'matchupDetails',
+      (payload: {
+        matchupId: string;
+        details?: MatchupDetails;
+        error?: { code: string; message: string };
+      }) => {
+        if (payload.matchupId !== matchupId) return;
+        if (payload.error) {
+          onError?.(payload.error);
+        } else if (payload.details) {
+          onResult(payload.details);
+        }
+      }
+    );
+    matchupDetailsListener = subscription;
+    LucraClient.subscribeMatchupDetails(matchupId);
+    return () => {
+      subscription.remove();
+      if (generation === matchupDetailsGeneration) {
+        matchupDetailsListener = null;
+        LucraClient.cancelMatchupDetailsSubscription();
+      }
+    };
+  },
   logout: (): Promise<void> => {
     return LucraClient.logout();
   },
@@ -809,6 +921,43 @@ export const LucraSDK = {
     return await LucraClient.joinTournament(tournamentId);
   },
 };
+
+/**
+ * React hook for live matchup details, scoped to the component lifecycle —
+ * the React equivalent of Android's lifecycle-scoped coroutines. Subscribes
+ * on mount (and whenever `matchupId` changes) and automatically cancels the
+ * native subscription on unmount, so it cannot leak.
+ *
+ * Pass `undefined` to stay idle (e.g. while the matchup id is still loading).
+ */
+export function useMatchupDetails(matchupId: string | undefined): {
+  details: MatchupDetails | null;
+  error: { code: string; message: string } | null;
+} {
+  const [details, setDetails] = React.useState<MatchupDetails | null>(null);
+  const [error, setError] = React.useState<{
+    code: string;
+    message: string;
+  } | null>(null);
+
+  React.useEffect(() => {
+    if (!matchupId) {
+      return;
+    }
+    setDetails(null);
+    setError(null);
+    return LucraSDK.subscribeToMatchupDetails(
+      matchupId,
+      (next) => {
+        setError(null);
+        setDetails(next);
+      },
+      setError
+    );
+  }, [matchupId]);
+
+  return { details, error };
+}
 
 export type LucraSDKError = {
   code:


### PR DESCRIPTION
This pull request introduces new APIs and improvements to the Lucra React Native SDK, focusing on enhanced access to matchup details, live updates, and improved consistency across platforms. The main changes include the addition of the `getMatchupDetails` and live subscription APIs, improved data mapping for matchup types/subtypes, and updates to the documentation and example app for better developer experience and clarity.

**New APIs and Features:**

* Added `getMatchupDetails(matchupId)` to the SDK, returning comprehensive matchup details including participant groups, scores, outcomes, and individual payouts. This mirrors the native apps' data and supports automated score tracking and auto settlement. [[1]](diffhunk://#diff-6543937716e601ab5b92a237e5b48027c14a2a7457514a1a399cb3a889877947R1-R9) [[2]](diffhunk://#diff-d8fd486350ab3c688a477c1cfb50c8123407d17cba9f61606f20d1fef273cb8fL717-R774) [[3]](diffhunk://#diff-62c4cd338e4b54f48820155ac54a09551589b703e0ae9813d5a3f3203ba008c7R512-R564)
* Added `subscribeToMatchupDetails(matchupId, onResult, onError?)`, providing live updates for matchup details as they change on the server, with an idempotent unsubscribe function. Also added the `useMatchupDetails` React hook for lifecycle-scoped subscriptions. [[1]](diffhunk://#diff-6543937716e601ab5b92a237e5b48027c14a2a7457514a1a399cb3a889877947R1-R9) [[2]](diffhunk://#diff-d8fd486350ab3c688a477c1cfb50c8123407d17cba9f61606f20d1fef273cb8fL717-R774)
* Updated TypeScript exports to include `MatchupDetails`, `MatchupGroupDetails`, `MatchupParticipantDetails`, `MatchupParticipantScore`, and related enums for strong typing.

**Platform Consistency and Data Mapping:**

* Standardized Android `getMatchup` to return canonical raw values for `type` and `subtype`, matching iOS and TypeScript types, and always including participant groups. [[1]](diffhunk://#diff-62c4cd338e4b54f48820155ac54a09551589b703e0ae9813d5a3f3203ba008c7L389-R409) [[2]](diffhunk://#diff-62c4cd338e4b54f48820155ac54a09551589b703e0ae9813d5a3f3203ba008c7R11-R17) [[3]](diffhunk://#diff-6543937716e601ab5b92a237e5b48027c14a2a7457514a1a399cb3a889877947R1-R9)
* Fixed iOS `getMatchup` to ensure `status`, `type`, and `subtype` are always present in the response.

### Before:
```
{
  "recreationGameExtension": {
    "game": {
      "categoryIds": [
        "SPORTS",
        "SPORTS"
      ],
      "name": "Axe Throwing",
      "imageUrl": "https://lucra-sandbox-uploads.s3.amazonaws.com/upload/irl_logos/AXE-THROWING.png",
      "id": "AXE-THROWING"
    },
    "buyInAmount": 0,
    "gameId": "AXE-THROWING"
  },
  "id": "6ddab208-4fa7-4756-963b-5e5f75a07dc3",
  "winningGroupId": "c55c8475-9bf9-4953-85bc-ac5fbe049da3",
  "isPublic": true,
  "type": "RecreationalGame",
  "subtype": "FreeForAll",
  "status": "CLOSED",
  "participantGroups": [],
  "createdAt": "2025-12-19T16:56:44.586046+00:00",
  "creatorId": "456e135e-b94c-4cbc-b32e-b66873282450",
  "creator": {
    "avatarUrl": "",
    "username": "JohnDoe",
    "socialConnectionId": null,
    "loyaltyPoints": 0,
    "id": "456e135e-b94c-4cbc-b32e-b66873282450"
  },
  "updatedAt": "2025-12-19T16:56:44.586046+00:00"
}
```

### Now:
```
{
  "recreationGameExtension": {
    "game": {
      "categoryIds": [
        "SPORTS",
        "SPORTS"
      ],
      "name": "Axe Throwing",
      "imageUrl": "https://lucra-sandbox-uploads.s3.amazonaws.com/upload/irl_logos/AXE-THROWING.png",
      "id": "AXE-THROWING"
    },
    "buyInAmount": 0,
    "gameId": "AXE-THROWING"
  },
  "id": "6ddab208-4fa7-4756-963b-5e5f75a07dc3",
  "winningGroupId": "c55c8475-9bf9-4953-85bc-ac5fbe049da3",
  "isPublic": true,
  "type": "RECREATIONAL_GAME",
  "subtype": "FREE_FOR_ALL",
  "status": "CLOSED",
  "participantGroups": [
    {
      "recreationalGameStatDetails": {
        "teamName": "Team 1",
        "score": ""
      },
      "outcome": "LOSS",
      "participants": [
        {
          "reward": {
            "iconUrl": "https://picsum.photos/200",
            "disclaimer": "*Can only be redeemed once per week",
            "descriptor": "10% off",
            "metadata": {
              "simple_data": "primitive_type_to_string",
              "custom_data": "{\"type\":\"food\",\"expiry\":\"2024-12-31\"}"
            },
            "title": "Client Appetizer",
            "bannerIconUrl": "https://picsum.photos/200",
            "rewardId": "reward_001"
          },
          "user": {
            "avatarUrl": "",
            "username": "JohnDoe",
            "socialConnectionId": null,
            "loyaltyPoints": 0,
            "id": "456e135e-b94c-4cbc-b32e-b66873282450"
          },
          "wager": 0
        }
      ],
      "createdAt": "2025-12-19T16:56:44.586046+00:00",
      "id": "bdcc6498-d16c-42ad-9451-10442791090f"
    },
    {
      "recreationalGameStatDetails": {
        "teamName": "Team",
        "score": ""
      },
      "outcome": "WIN",
      "participants": [
        {
          "reward": {
            "iconUrl": "https://picsum.photos/200",
            "disclaimer": "*Can only be redeemed once per week",
            "descriptor": "10% off",
            "metadata": {
              "simple_data": "primitive_type_to_string",
              "custom_data": "{\"type\":\"food\",\"expiry\":\"2024-12-31\"}"
            },
            "title": "Client Appetizer",
            "bannerIconUrl": "https://picsum.photos/200",
            "rewardId": "reward_001"
          },
          "user": {
            "avatarUrl": "",
            "username": "JohnDoe",
            "socialConnectionId": null,
            "loyaltyPoints": 0,
            "id": "6e2267b5-03aa-4ec0-971d-2647c3ee7152"
          },
          "wager": 0
        }
      ],
      "createdAt": "2025-12-19T16:56:51.351246+00:00",
      "id": "c55c8475-9bf9-4953-85bc-ac5fbe049da3"
    }
  ],
  "createdAt": "2025-12-19T16:56:44.586046+00:00",
  "creatorId": "456e135e-b94c-4cbc-b32e-b66873282450",
  "creator": {
    "avatarUrl": "",
    "username": "JohnDoe",
    "socialConnectionId": null,
    "loyaltyPoints": 0,
    "id": "456e135e-b94c-4cbc-b32e-b66873282450"
  },
  "updatedAt": "2025-12-23T16:56:44.586046+00:00"
}
```

### getMatchupDetails (NEW)
```
{
  "groups": [
    {
      "id": "bdcc6498-d16c-42ad-9451-10442791090f",
      "name": "Team 1",
      "outcome": "LOSS",
      "participants": [
        {
          "avatarUrl": "",
          "individualPayout": 0,
          "userId": "456e135e-b94c-4cbc-b32e-b66873282450",
          "username": "JohnDoe"
        }
      ]
    },
    {
      "id": "c55c8475-9bf9-4953-85bc-ac5fbe049da3",
      "name": "Team",
      "outcome": "WIN",
      "participants": [
        {
          "avatarUrl": "",
          "individualPayout": 0,
          "userId": "6e2267b5-03aa-4ec0-971d-2647c3ee7152",
          "username": "JohnDoe"
        }
      ]
    }
  ],
  "matchup": {
    "createdAt": "2025-12-19T16:56:44.586046+00:00",
    "creator": {
      "avatarUrl": "",
      "id": "456e135e-b94c-4cbc-b32e-b66873282450",
      "loyaltyPoints": 0,
      "socialConnectionId": null,
      "username": "JohnDoe"
    },
    "creatorId": "456e135e-b94c-4cbc-b32e-b66873282450",
    "id": "6ddab208-4fa7-4756-963b-5e5f75a07dc3",
    "isPublic": true,
    "participantGroups": [
      {
        "createdAt": "2025-12-19T16:56:44.586046+00:00",
        "id": "bdcc6498-d16c-42ad-9451-10442791090f",
        "outcome": "LOSS",
        "participants": [
          {
            "reward": {
              "bannerIconUrl": "https://picsum.photos/200",
              "descriptor": "10% off",
              "disclaimer": "*Can only be redeemed once per week",
              "iconUrl": "https://picsum.photos/200",
              "metadata": {
                "custom_data": "{\"type\":\"food\",\"expiry\":\"2024-12-31\"}",
                "simple_data": "primitive_type_to_string"
              },
              "rewardId": "reward_001",
              "title": "Client Appetizer"
            },
            "user": {
              "avatarUrl": "",
              "id": "456e135e-b94c-4cbc-b32e-b66873282450",
              "loyaltyPoints": 0,
              "socialConnectionId": null,
              "username": "JohnDoe"
            },
            "wager": 0
          }
        ],
        "recreationalGameStatDetails": {
          "score": "",
          "teamName": "Team 1"
        }
      },
      {
        "createdAt": "2025-12-19T16:56:51.351246+00:00",
        "id": "c55c8475-9bf9-4953-85bc-ac5fbe049da3",
        "outcome": "WIN",
        "participants": [
          {
            "reward": {
              "bannerIconUrl": "https://picsum.photos/200",
              "descriptor": "10% off",
              "disclaimer": "*Can only be redeemed once per week",
              "iconUrl": "https://picsum.photos/200",
              "metadata": {
                "custom_data": "{\"type\":\"food\",\"expiry\":\"2024-12-31\"}",
                "simple_data": "primitive_type_to_string"
              },
              "rewardId": "reward_001",
              "title": "Client Appetizer"
            },
            "user": {
              "avatarUrl": "",
              "id": "6e2267b5-03aa-4ec0-971d-2647c3ee7152",
              "loyaltyPoints": 0,
              "socialConnectionId": null,
              "username": "JohnDoe"
            },
            "wager": 0
          }
        ],
        "recreationalGameStatDetails": {
          "score": "",
          "teamName": "Team"
        }
      }
    ],
    "recreationGameExtension": {
      "buyInAmount": 0,
      "game": {
        "categoryIds": [
          "SPORTS",
          "SPORTS"
        ],
        "id": "AXE-THROWING",
        "imageUrl": "https://lucra-sandbox-uploads.s3.amazonaws.com/upload/irl_logos/AXE-THROWING.png",
        "name": "Axe Throwing"
      },
      "gameId": "AXE-THROWING"
    },
    "status": "CLOSED",
    "subtype": "FREE_FOR_ALL",
    "type": "RECREATIONAL_GAME",
    "updatedAt": "2025-12-23T16:56:44.586046+00:00",
    "winningGroupId": "c55c8475-9bf9-4953-85bc-ac5fbe049da3"
  },
  "participantScores": [
    {
      "avatarUrl": "",
      "groupId": "bdcc6498-d16c-42ad-9451-10442791090f",
      "place": 1,
      "userId": "456e135e-b94c-4cbc-b32e-b66873282450",
      "username": "JohnDoe"
    },
    {
      "avatarUrl": "",
      "groupId": "c55c8475-9bf9-4953-85bc-ac5fbe049da3",
      "place": 2,
      "userId": "6e2267b5-03aa-4ec0-971d-2647c3ee7152",
      "username": "JohnDoe"
    }
  ]
}
```

### Added subscription:
<img width="400" alt="image" src="https://github.com/user-attachments/assets/224fecc0-1d11-4ac7-ac21-14715e5c9805" />


**Documentation Updates:**

* Expanded the headless functions documentation to cover the new `getMatchupDetails` and subscription APIs, including usage examples, detailed response shapes, and error codes. Updated sample responses to use canonical enum values. [[1]](diffhunk://#diff-500e49ccbd17e65185a925b817ffec0131d1f6b48c34a4ecfd73ac974302718fR153-R162) [[2]](diffhunk://#diff-500e49ccbd17e65185a925b817ffec0131d1f6b48c34a4ecfd73ac974302718fL165-R174) [[3]](diffhunk://#diff-500e49ccbd17e65185a925b817ffec0131d1f6b48c34a4ecfd73ac974302718fR220-R388) [[4]](diffhunk://#diff-38da881f0394b276252341a72a83cd18ad0030ea93a522d8a37e87946e6cec09R18-R19) [[5]](diffhunk://#diff-38da881f0394b276252341a72a83cd18ad0030ea93a522d8a37e87946e6cec09L27-R30)
* Added release notes summarizing these changes and highlighting breaking changes for Android consumers.

**Example App Enhancements:**

* Added a syntax-highlighted JSON viewer, result copying, and live subscription controls to the API example screen for easier testing and debugging of the new APIs. [[1]](diffhunk://#diff-47ba6a41f1ab48e8d0042cf4410da8034ee7a905aa9a462b772880aeb1c5a2f3R26-R81) [[2]](diffhunk://#diff-47ba6a41f1ab48e8d0042cf4410da8034ee7a905aa9a462b772880aeb1c5a2f3R125-R149)

These updates provide a more robust, consistent, and developer-friendly interface for accessing and tracking Lucra matchups across platforms.

**References:** [[1]](diffhunk://#diff-6543937716e601ab5b92a237e5b48027c14a2a7457514a1a399cb3a889877947R1-R9) [[2]](diffhunk://#diff-d8fd486350ab3c688a477c1cfb50c8123407d17cba9f61606f20d1fef273cb8fL717-R774) [[3]](diffhunk://#diff-62c4cd338e4b54f48820155ac54a09551589b703e0ae9813d5a3f3203ba008c7L389-R409) [[4]](diffhunk://#diff-62c4cd338e4b54f48820155ac54a09551589b703e0ae9813d5a3f3203ba008c7R11-R17) [[5]](diffhunk://#diff-62c4cd338e4b54f48820155ac54a09551589b703e0ae9813d5a3f3203ba008c7R512-R564) [[6]](diffhunk://#diff-500e49ccbd17e65185a925b817ffec0131d1f6b48c34a4ecfd73ac974302718fR153-R162) [[7]](diffhunk://#diff-500e49ccbd17e65185a925b817ffec0131d1f6b48c34a4ecfd73ac974302718fL165-R174) [[8]](diffhunk://#diff-500e49ccbd17e65185a925b817ffec0131d1f6b48c34a4ecfd73ac974302718fR220-R388) [[9]](diffhunk://#diff-38da881f0394b276252341a72a83cd18ad0030ea93a522d8a37e87946e6cec09R18-R19) [[10]](diffhunk://#diff-38da881f0394b276252341a72a83cd18ad0030ea93a522d8a37e87946e6cec09L27-R30) [[11]](diffhunk://#diff-47ba6a41f1ab48e8d0042cf4410da8034ee7a905aa9a462b772880aeb1c5a2f3R26-R81) [[12]](diffhunk://#diff-47ba6a41f1ab48e8d0042cf4410da8034ee7a905aa9a462b772880aeb1c5a2f3R125-R149)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added getMatchupDetails API, live matchup-details subscription, and useMatchupDetails hook for real-time group, payout, and participant score data
  * Example app: improved pretty-printing and a “Matchup Details” action with copyable JSON output

* **Bug Fixes**
  * Normalized status/type/subtype values across platforms
  * Corrected socialConnectionId and numeric leaderboard/place handling

* **Documentation**
  * Expanded docs and examples for matchup details, errors, and live-update lifecycle
<!-- end of auto-generated comment: release notes by coderabbit.ai -->