### PR TITLE
Bumped android to 6.6.1 and updated notes to depict the next release

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -111,8 +111,8 @@ repositories {
 def kotlin_version = getExtOrDefault("kotlinVersion")
 
 dependencies {
-  implementation("com.lucrasports.sdk:sdk-core:6.6.0")
-  implementation("com.lucrasports.sdk:sdk-ui:6.6.0")
+  implementation("com.lucrasports.sdk:sdk-core:6.6.1")
+  implementation("com.lucrasports.sdk:sdk-ui:6.6.1")
   coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.4")
   implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.7.0")
 

--- a/docs/SDK_RELEASE_NOTES.md
+++ b/docs/SDK_RELEASE_NOTES.md
@@ -1,4 +1,5 @@
-# UPCOMING
+# 5.6.0
+* Bumped Android to [6.6.1](https://github.com/Lucra-Sports/lucra-android-sdk/releases/tag/6.6.1)
 * Added `LucraSDK.handleLucraNotification(payload)` for push notifications: extracts the Lucra deeplink from a tapped
   notification's data payload and resolves it to `{ flow, matchupId, ... }` **without presenting UI**, so headless
   integrations can route to their own screens. See [Push Notifications](1.2.3_push_notifications.md).


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Lucra Sports Android SDK dependencies (sdk-core and sdk-ui) from version 6.6.0 to 6.6.1.
  * Updated release notes documentation to reflect version 5.6.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->