### PR TITLE
docs: use externalId metadata key in configure user docs

### DIFF
--- a/docs/1.2.9_headless_interactions.md
+++ b/docs/1.2.9_headless_interactions.md
@@ -60,7 +60,7 @@ If `configure` is invoked before the Lucra session is established, the request i
 
 **User metadata implications**
 
-- Use `metadata` to pass identifiers and traits from your system. This is a Map of Strings to Strings, an `external_id` entry (example: `"external_id" to "clientUserId"`) is recommended at minimum to bind your users to Lucra users. Which will help for score submission and other identifying properties from Lucra systems.
+- Use `metadata` to pass identifiers and traits from your system. This is a Map of Strings to Strings, an `externalId` entry (example: `"externalId" to "clientUserId"`) is recommended at minimum to bind your users to Lucra users. Which will help for score submission and other identifying properties from Lucra systems.
 
 Provide user information so Lucra can create or update the user profile:
 
@@ -79,7 +79,7 @@ await LucraSDK.configureUser({
     state: 'NY',                  // optional
     zip: '10001',                 // optional
   },
-  metadata: { "external_id": "..."}, // optional string map to help bind Lucra users to your users
+  metadata: { "externalId": "..."}, // optional string map to help bind Lucra users to your users
 });
 
 const user = await LucraSDK.getUser();


### PR DESCRIPTION
## Summary

The configure-user documentation referenced the metadata key as `external_id`, but the native SDKs read it as `externalId`. Metadata passes straight through the React Native layer, so the docs are the only surface to correct.

This PR aligns the documented key with what the native code expects.

## Changes

- `docs/1.2.9_headless_interactions.md` — `external_id` → `externalId` (2 occurrences)

## Verification

Confirmed the native iOS/Android SDKs read the metadata map with the literal key `"externalId"`. Docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K5qYcYRmEtESMJE1LzCkep

---
_Generated by [Claude Code](https://claude.ai/code/session_01K5qYcYRmEtESMJE1LzCkep)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated guidance on metadata key naming for user configuration from `external_id` to `externalId`, including updated examples and explanatory text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->