### PR TITLE
feat: TV-1503 add autoJoin init param and manual autoJoinTournaments method

### DIFF
--- a/android/src/main/kotlin/com/lucrasdk/Libs/ErrorMapper.kt
+++ b/android/src/main/kotlin/com/lucrasdk/Libs/ErrorMapper.kt
@@ -75,4 +75,11 @@ object ErrorMapper {
     ) {
         mapTournamentFailure(promise, error.failure)
     }
+
+    fun rejectAutoJoinTournamentsError(
+        promise: Promise,
+        error: PoolTournament.AutoJoinTournamentsResult.Failure
+    ) {
+        mapTournamentFailure(promise, error.failure)
+    }
 }

--- a/android/src/main/kotlin/com/lucrasdk/LucraClientModule.kt
+++ b/android/src/main/kotlin/com/lucrasdk/LucraClientModule.kt
@@ -1,5 +1,6 @@
 package com.lucrasdk
 
+import ErrorMapper.rejectAutoJoinTournamentsError
 import ErrorMapper.rejectJoinTournamentError
 import ErrorMapper.rejectRecommendedTournamentsError
 import ErrorMapper.rejectRetrieveTournamentError
@@ -123,6 +124,8 @@ class LucraClientModule(private val context: ReactApplicationContext) :
             clientTheme = ClientTheme(colorStyle, fontFamily)
         }
 
+        val autoJoin = if (options.hasKey("autoJoin")) options.getBoolean("autoJoin") else true
+
         try {
             LucraClient.initialize(
                 application = context.applicationContext as Application,
@@ -130,6 +133,7 @@ class LucraClientModule(private val context: ReactApplicationContext) :
                 lucraUiProvider = buildLucraUIInstance(),
                 environment = LucraUtils.getLucraEnvironment(environment),
                 clientTheme = clientTheme,
+                autoJoin = autoJoin,
                 customLogger = object : LucraLogger.Logger {
                     override fun logNonFatalException(exception: Throwable) {
                         Log.e("LucraClient RN", exception.message, exception)
@@ -1000,6 +1004,23 @@ class LucraClientModule(private val context: ReactApplicationContext) :
                     promise.resolve(LucraMapper.tournamentsMatchupToMap(result.tournament))
                 }
 
+            }
+        }
+    }
+
+    @ReactMethod
+    fun autoJoinTournaments(promise: Promise) {
+        LucraClient().autoJoinTournaments { result ->
+            when (result) {
+                is PoolTournament.AutoJoinTournamentsResult.Failure -> {
+                    rejectAutoJoinTournamentsError(promise, result)
+                }
+
+                is PoolTournament.AutoJoinTournamentsResult.AutoJoinedTournamentsOutput -> {
+                    val writableArray = Arguments.createArray()
+                    result.tournamentIds.forEach { writableArray.pushString(it) }
+                    promise.resolve(writableArray)
+                }
             }
         }
     }

--- a/docs/1.2.0_initialize_client.md
+++ b/docs/1.2.0_initialize_client.md
@@ -8,6 +8,7 @@ Initialize `LucraSDK` once at app startup. Initialization is asynchronous becaus
 - `apiKey` (string, required): API key matching your environment.
 - `environment` (LucraSDK.ENVIRONMENT, required): `SANDBOX` or `PRODUCTION`.
 - `theme` (object, optional but recommended): Overrides Lucra UI appearance. See [Theming](1.2.1_theming.md).
+- `autoJoin` (boolean, optional, default `true`): When `true`, the SDK automatically joins all eligible free-entry tournaments as soon as the user authenticates. Set to `false` to suppress automatic joining and call `LucraSDK.autoJoinTournaments()` manually instead.
 
 ## Example Initialization
 
@@ -65,6 +66,17 @@ if (LucraSDK.ready) {
 }
 
 ```
+
+## Manual Auto-Join
+
+If you initialize with `autoJoin: false`, or want to trigger joining on demand (e.g., after a location permission is granted), call:
+
+```ts
+const joinedIds = await LucraSDK.autoJoinTournaments();
+// joinedIds: string[] — IDs of tournaments joined in this call
+```
+
+The call respects the same prerequisites as automatic joining (location permission granted, user verified, feature enabled). It rejects with a structured error code if any prerequisite isn't met. The `onAutoJoinedTournaments` contest-listener event fires alongside the promise, so existing listeners continue to work regardless of whether joining was triggered automatically or manually.
 
 ## After Initialization
 

--- a/docs/SDK_RELEASE_NOTES.md
+++ b/docs/SDK_RELEASE_NOTES.md
@@ -1,3 +1,10 @@
+# 5.7.0
+* Added `autoJoin` boolean to `LucraSDKParams` (optional, defaults to `true`). When `true`, the SDK automatically joins all eligible free-entry tournaments as soon as the user authenticates. Set to `false` to suppress automatic joining and drive it yourself.
+  * Passed through to `LucraClient.initialize(autoJoin:)` on Android and `LucraEnvironmentOverrides.init(autoJoin:)` on iOS. Both platforms previously hardcoded their own defaults (Android `true`, iOS `false`); the bridge now makes `true` the explicit cross-platform default.
+* Added `LucraSDK.autoJoinTournaments(): Promise<string[]>` — a headless function to manually trigger the auto-join flow. Returns the IDs of all tournaments that were joined in that call. Useful when `autoJoin` is disabled at init time or when you want to re-run joining on demand (e.g., after a location permission grant). Rejects with a structured error code if prerequisites aren't met (location not granted, user unverified, feature disabled, etc.). The `onAutoJoinedTournaments` contest-listener event continues to fire alongside the promise resolution.
+  * Android: unwraps `AutoJoinTournamentsResult.AutoJoinedTournamentsOutput.tournamentIds`
+  * iOS: unwraps `Result<[String], TournamentError>` success value
+
 # 5.6.0
 * Bumped Android to [6.6.1](https://github.com/Lucra-Sports/lucra-android-sdk/releases/tag/6.6.1)
 * Added `LucraSDK.handleLucraNotification(payload)` for push notifications: extracts the Lucra deeplink from a tapped

--- a/ios/LucraClient.mm
+++ b/ios/LucraClient.mm
@@ -251,6 +251,11 @@ RCT_EXPORT_METHOD(tournamentMatchup : (NSString *)idString resolve : (
   [swiftClient tournamentMatchup:idString resolve:resolve reject:reject];
 }
 
+RCT_EXPORT_METHOD(autoJoinTournaments : (RCTPromiseResolveBlock)
+                      resolve reject : (RCTPromiseRejectBlock)reject) {
+  [swiftClient autoJoinTournamentsWithResolve:resolve reject:reject];
+}
+
 RCT_EXPORT_METHOD(joinTournament : (NSString *)idString resolve : (
     RCTPromiseResolveBlock)resolve reject : (RCTPromiseRejectBlock)reject) {
   [swiftClient joinTournament:idString resolve:resolve reject:reject];

--- a/ios/LucraSwiftClient.swift
+++ b/ios/LucraSwiftClient.swift
@@ -69,13 +69,16 @@ private enum ErrorCode {
     let environment = LucraUtils.stringToEnvironment(
       options["environment"] as? String)
 
+    let autoJoin = options["autoJoin"] as? Bool ?? true
+
     nativeClient = LucraSDK.LucraClient(
       config: .init(
         environment: .init(
           apiKey: apiKey,
           environment: environment,
           urlScheme: urlScheme,
-          merchantID: merchantID
+          merchantID: merchantID,
+          autoJoin: autoJoin
         ),
         appearance: clientTheme
       )
@@ -988,6 +991,21 @@ private enum ErrorCode {
       switch result {
       case .success(let tournament):
         resolve(tournamentsMatchupToMap(tournament: tournament))
+      case .failure(let error):
+        rejectLucraError(reject, error: error)
+      }
+    }
+  }
+
+  @objc public func autoJoinTournaments(
+    resolve: @escaping RCTPromiseResolveBlock,
+    reject: @escaping RCTPromiseRejectBlock
+  ) {
+    Task { @MainActor in
+      let result = await self.nativeClient.api.autoJoinTournaments()
+      switch result {
+      case .success(let tournamentIds):
+        resolve(tournamentIds)
       case .failure(let error):
         rejectLucraError(reject, error: error)
       }

--- a/src/NativeLucraClient.ts
+++ b/src/NativeLucraClient.ts
@@ -57,6 +57,7 @@ interface Spec extends TurboModule {
   getRecommendedTournaments: (params: Object) => Promise<Object[]>;
   tournamentMatchup: (tournamentId: string) => Promise<Object>;
   joinTournament: (tournamentId: string) => Promise<void>;
+  autoJoinTournaments: () => Promise<string[]>;
 
   // Client <-> SDK listener types
   addListener: (eventType: string) => void;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -185,6 +185,7 @@ export type LucraSDKParams = {
   };
   urlScheme?: string;
   merchantID?: string;
+  autoJoin?: boolean;
 };
 
 export type MatchupStatus =
@@ -949,6 +950,9 @@ export const LucraSDK = {
   },
   joinTournament: async (tournamentId: string) => {
     return await LucraClient.joinTournament(tournamentId);
+  },
+  autoJoinTournaments: async (): Promise<string[]> => {
+    return await LucraClient.autoJoinTournaments();
   },
 };
 


### PR DESCRIPTION

https://lucrasports.atlassian.net/browse/TV-1503

## Summary

- **`autoJoin` on initialization** — adds an optional `autoJoin?: boolean` to `LucraSDKParams` (defaults to `true` on both platforms). The value is passed through to the native `LucraClient` on both Android and iOS at init time. Note: iOS natively defaults to `false`, so the bridge explicitly passes `true` when the param is omitted.
- **`LucraSDK.autoJoinTournaments()`** — exposes a manual trigger that returns `Promise<string[]>` containing the IDs of tournaments that were joined. Both platforms unwrap their platform-specific result types so the JS surface is identical:
  - Android: `AutoJoinedTournamentsOutput.tournamentIds: List<String>` → `WritableArray` of strings
  - iOS: `Result<[String], TournamentError>` success value resolves directly as `string[]`
  - Errors on both platforms reject the promise using existing error-mapping infrastructure

## Files changed

| File | Change |
|---|---|
| `src/index.tsx` | Add `autoJoin?: boolean` to `LucraSDKParams`; expose `autoJoinTournaments()` on `LucraSDK` |
| `src/NativeLucraClient.ts` | Add `autoJoinTournaments(): Promise<string[]>` to TurboModule spec |
| `android/.../LucraClientModule.kt` | Read `autoJoin` from init options; add `autoJoinTournaments` React method |
| `android/.../ErrorMapper.kt` | Add `rejectAutoJoinTournamentsError` for consistent error handling |
| `ios/LucraSwiftClient.swift` | Read `autoJoin` from init options; add `autoJoinTournaments` Swift method |
| `ios/LucraClient.mm` | Add `RCT_EXPORT_METHOD` forwarding to Swift client |

## Test plan

- [ ] Initialize SDK without `autoJoin` param → both platforms default to `true` (auto-join fires on sign-in)
- [ ] Initialize SDK with `autoJoin: false` → automatic join on sign-in is suppressed
- [ ] Call `LucraSDK.autoJoinTournaments()` manually → resolves with array of joined tournament IDs
- [ ] Verify `onAutoJoinedTournaments` event still fires (both automatic and manual paths)
- [ ] Verify promise rejects with correct error code when prerequisites aren't met (e.g. location not granted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FCcVP3wGNRxDcuMMYh11JA

---
_Generated by [Claude Code](https://claude.ai/code/session_01FCcVP3wGNRxDcuMMYh11JA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `autoJoinTournaments` API to the SDK for joining tournaments and returning the joined tournament IDs.
  * Added an optional `autoJoin` configuration setting during initialization, with automatic default behavior when not provided.
  * Exposed the new tournament auto-join capability across both Android and iOS native integrations.

* **Bug Fixes**
  * Improved error handling for auto-join tournament failures so promise rejections now return clearer mapped errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->