### PR TITLE
TV-1789 - 5.8.0 - MiniGames

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -111,8 +111,8 @@ repositories {
 def kotlin_version = getExtOrDefault("kotlinVersion")
 
 dependencies {
-  implementation("com.lucrasports.sdk:sdk-core:6.6.1")
-  implementation("com.lucrasports.sdk:sdk-ui:6.6.1")
+  implementation("com.lucrasports.sdk:sdk-core:6.7.0")
+  implementation("com.lucrasports.sdk:sdk-ui:6.7.0")
   coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.4")
   implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.7.0")
 

--- a/android/src/main/kotlin/com/lucrasdk/Libs/LucraMapper.kt
+++ b/android/src/main/kotlin/com/lucrasdk/Libs/LucraMapper.kt
@@ -7,6 +7,8 @@ import com.facebook.react.bridge.WritableNativeMap
 import com.lucrasdk.Libs.LucraUtils.Companion.convertReadableMapToStringMap
 import com.lucrasdk.Libs.LucraUtils.Companion.convertStringMapToWritableMap
 import com.lucrasports.LucraUser
+import com.lucrasports.minigame.MiniGameCatalogConfig
+import com.lucrasports.minigame.MiniGameCatalogItem
 import com.lucrasports.matchup.ParticipantGroupOutcome
 import com.lucrasports.matchup.RecreationalGame
 import com.lucrasports.matchup.TopLevelMatchupSubType
@@ -304,6 +306,33 @@ object LucraMapper {
         map.putString("claimedAt", achievement.claimedAt?.let { isoUtcDf.format(it) })
         map.putInt("currentProgress", achievement.currentProgress)
         achievement.achievement?.let { map.putMap("achievement", achievementDefinitionToMap(it)) }
+        return map
+    }
+
+    fun miniGameCatalogConfigToMap(config: MiniGameCatalogConfig): WritableMap {
+        val map = Arguments.createMap()
+        map.putString("id", config.id)
+        map.putString("gameId", config.gameId)
+        map.putString("mode", config.mode)
+        config.wagerAmount?.let { map.putDouble("wagerAmount", it) } ?: map.putNull("wagerAmount")
+        config.groupSize?.let { map.putInt("groupSize", it) } ?: map.putNull("groupSize")
+        map.putString("createdAt", config.createdAt)
+        map.putString("updatedAt", config.updatedAt)
+        return map
+    }
+
+    fun miniGameCatalogItemToMap(item: MiniGameCatalogItem): WritableMap {
+        val map = Arguments.createMap()
+        map.putString("gameId", item.gameId)
+        map.putString("name", item.name)
+        map.putString("description", item.description)
+        map.putString("imageUrl", item.imageUrl)
+        map.putString("videoUrl", item.videoUrl)
+        map.putString("createdAt", item.createdAt)
+        map.putString("updatedAt", item.updatedAt)
+        val configArray = Arguments.createArray()
+        item.config.forEach { configArray.pushMap(miniGameCatalogConfigToMap(it)) }
+        map.putArray("config", configArray)
         return map
     }
 

--- a/android/src/main/kotlin/com/lucrasdk/Libs/LucraUtils.kt
+++ b/android/src/main/kotlin/com/lucrasdk/Libs/LucraUtils.kt
@@ -72,6 +72,9 @@ class LucraUtils {
                     )
                 }
                 "miniGamesHome" -> LucraUiProvider.LucraFlow.MinigamesHome
+                "miniGamesProfile" -> LucraUiProvider.LucraFlow.MinigamesProfile
+                "miniGamesRewards" -> LucraUiProvider.LucraFlow.MinigamesRewards
+                "miniGamesMatchupDetails" -> LucraUiProvider.LucraFlow.MinigameMatchupDetails(matchupId!!)
                 "achievements" -> LucraUiProvider.LucraFlow.Achievements
                 // TODO not yet publicly available within Android SDK
 //        "sportsContestDetails" -> LucraUiProvider.LucraFlow.SportsContestDetails

--- a/android/src/main/kotlin/com/lucrasdk/Libs/LucraUtils.kt
+++ b/android/src/main/kotlin/com/lucrasdk/Libs/LucraUtils.kt
@@ -71,6 +71,7 @@ class LucraUtils {
                         matchupId = matchupId,
                     )
                 }
+                "miniGamesHome" -> LucraUiProvider.LucraFlow.MinigamesHome
                 "achievements" -> LucraUiProvider.LucraFlow.Achievements
                 // TODO not yet publicly available within Android SDK
 //        "sportsContestDetails" -> LucraUiProvider.LucraFlow.SportsContestDetails

--- a/android/src/main/kotlin/com/lucrasdk/LucraClientModule.kt
+++ b/android/src/main/kotlin/com/lucrasdk/LucraClientModule.kt
@@ -571,6 +571,23 @@ class LucraClientModule(private val context: ReactApplicationContext) :
 
     @Suppress("DEPRECATION")
     @ReactMethod
+    fun getMiniGames(promise: Promise) {
+        LucraClient().getMiniGames { result ->
+            when (result) {
+                is MiniGameInteractions.GetMiniGamesResult.Success -> {
+                    val array = Arguments.createArray()
+                    result.games.forEach { array.pushMap(LucraMapper.miniGameCatalogItemToMap(it)) }
+                    promise.resolve(array)
+                }
+
+                is MiniGameInteractions.GetMiniGamesResult.Failure ->
+                    rejectLucraError(promise, result.failure)
+            }
+        }
+    }
+
+    @Suppress("DEPRECATION")
+    @ReactMethod
     fun getUserTournamentRewards(params: ReadableMap, promise: Promise) {
         val tournamentId = params.getString("tournamentId")
         val viewed = params.optionalBoolean("viewed")

--- a/docs/1.2.7_lucraflows.md
+++ b/docs/1.2.7_lucraflows.md
@@ -24,6 +24,7 @@ const Flows = {
   MATCHUP_DETAILS: 'matchupDetails',
   DEMOGRAPHIC_COLLECTION: 'demographicCollection',
   MINI_GAME: 'miniGame',
+  MINI_GAMES_HOME: 'miniGamesHome',
   ACHIEVEMENTS: 'achievements',
 } as const;
 ```
@@ -41,6 +42,7 @@ await LucraSDK.present({ name: LucraSDK.FLOW.WITHDRAW_FUNDS });
 await LucraSDK.present({ name: LucraSDK.FLOW.PUBLIC_FEED });
 await LucraSDK.present({ name: LucraSDK.FLOW.MY_MATCHUP });
 await LucraSDK.present({ name: LucraSDK.FLOW.DEMOGRAPHIC_COLLECTION });
+await LucraSDK.present({ name: LucraSDK.FLOW.MINI_GAMES_HOME });
 ```
 
 Flows that require parameters:
@@ -104,6 +106,7 @@ await LucraSDK.present({ name: LucraSDK.FLOW.ACHIEVEMENTS });
   - `gameMode` (MiniGameMode, required): Session mode.
   - `amount` (number, optional): Buy-in amount; ignored for `PRACTICE`.
   - `matchupId` (string, optional): Join an existing matchup.
+- `MINI_GAMES_HOME`: Present the Mini Games home experience (profile pill, achievement card, game carousel, and featured tournament). Its sub-screens — mini games profile, rewards, matchup details, and game-mode selection — are reachable by navigating within this flow. No params.
 - `ACHIEVEMENTS`: Open the achievements screen.
 
 ### Dismissing Full-Screen Flows

--- a/docs/1.2.7_lucraflows.md
+++ b/docs/1.2.7_lucraflows.md
@@ -25,6 +25,9 @@ const Flows = {
   DEMOGRAPHIC_COLLECTION: 'demographicCollection',
   MINI_GAME: 'miniGame',
   MINI_GAMES_HOME: 'miniGamesHome',
+  MINI_GAMES_PROFILE: 'miniGamesProfile',
+  MINI_GAMES_REWARDS: 'miniGamesRewards',
+  MINI_GAMES_MATCHUP_DETAILS: 'miniGamesMatchupDetails',
   ACHIEVEMENTS: 'achievements',
 } as const;
 ```
@@ -43,6 +46,17 @@ await LucraSDK.present({ name: LucraSDK.FLOW.PUBLIC_FEED });
 await LucraSDK.present({ name: LucraSDK.FLOW.MY_MATCHUP });
 await LucraSDK.present({ name: LucraSDK.FLOW.DEMOGRAPHIC_COLLECTION });
 await LucraSDK.present({ name: LucraSDK.FLOW.MINI_GAMES_HOME });
+await LucraSDK.present({ name: LucraSDK.FLOW.MINI_GAMES_PROFILE });
+await LucraSDK.present({ name: LucraSDK.FLOW.MINI_GAMES_REWARDS });
+```
+
+The Mini Games matchup-details flow requires a matchup ID:
+
+```ts
+await LucraSDK.present({
+  name: LucraSDK.FLOW.MINI_GAMES_MATCHUP_DETAILS,
+  matchupId: 'MATCHUP_ID',
+});
 ```
 
 Flows that require parameters:
@@ -106,7 +120,11 @@ await LucraSDK.present({ name: LucraSDK.FLOW.ACHIEVEMENTS });
   - `gameMode` (MiniGameMode, required): Session mode.
   - `amount` (number, optional): Buy-in amount; ignored for `PRACTICE`.
   - `matchupId` (string, optional): Join an existing matchup.
-- `MINI_GAMES_HOME`: Present the Mini Games home experience (profile pill, achievement card, game carousel, and featured tournament). Its sub-screens — mini games profile, rewards, matchup details, and game-mode selection — are reachable by navigating within this flow. No params.
+- `MINI_GAMES_HOME`: Present the Mini Games home experience (profile pill, achievement card, game carousel, and featured tournament). Its sub-screens are also reachable directly via the flows below. No params.
+- `MINI_GAMES_PROFILE`: Present the Mini Games profile (avatar, username, balance, stats, recent results). No params.
+- `MINI_GAMES_REWARDS`: Present the Mini Games rewards screen (achievement rewards grouped by game). No params.
+- `MINI_GAMES_MATCHUP_DETAILS`: Present the Mini Games matchup result screen. Required params:
+  - `matchupId` (string): Lucra matchup ID.
 - `ACHIEVEMENTS`: Open the achievements screen.
 
 ### Dismissing Full-Screen Flows

--- a/docs/5.1_mini_games_headless.md
+++ b/docs/5.1_mini_games_headless.md
@@ -4,6 +4,41 @@
 
 Use these APIs to start mini game sessions without showing Lucra UI. All calls require `LucraSDK.init` to be completed and the user configured.
 
+## List Mini Games
+
+Returns every mini game enabled for the current tenant, each with the tenant's subscribed config options (mode, wager amount, group size). Use this to build a custom mini games catalog UI.
+
+```ts
+import { LucraSDK, MiniGameCatalogItem } from '@lucra-sports/lucra-react-native-sdk';
+
+const games: MiniGameCatalogItem[] = await LucraSDK.getMiniGames();
+```
+
+Each `MiniGameCatalogItem` has:
+
+```ts
+type MiniGameCatalogItem = {
+  gameId: string;
+  name: string;
+  description?: string;
+  imageUrl?: string;
+  videoUrl?: string;
+  createdAt: string;
+  updatedAt: string;
+  config: MiniGameCatalogConfig[];
+};
+
+type MiniGameCatalogConfig = {
+  id: string;
+  gameId: string;
+  mode: string; // 'practice' | '1v1' | 'free_for_all' | 'tournament'
+  wagerAmount?: number; // USD; omitted for free modes
+  groupSize?: number; // only set for free-for-all
+  createdAt: string;
+  updatedAt: string;
+};
+```
+
 ## Start Mini Game
 
 ```ts

--- a/docs/SDK_RELEASE_NOTES.md
+++ b/docs/SDK_RELEASE_NOTES.md
@@ -1,4 +1,6 @@
 # 5.8.0
+* Bumped iOS to [5.6.0](https://github.com/Lucra-Sports/lucra-ios-sdk/releases/tag/5.6.0)
+* Bumped Android to [6.7.0](https://github.com/Lucra-Sports/lucra-android-sdk/releases/tag/6.7.0)
 * Mapped the new Mini Games surface from the native SDKs' Minigames epic through the React Native library:
   * Added `LucraSDK.getMiniGames(): Promise<MiniGameCatalogItem[]>` — a headless function that lists every mini game enabled for the current tenant, each with the tenant's subscribed config options (mode, wager amount, group size). No Lucra UI is presented.
   * Added the exported `MiniGameCatalogItem` and `MiniGameCatalogConfig` TypeScript types describing the catalog response.

--- a/docs/SDK_RELEASE_NOTES.md
+++ b/docs/SDK_RELEASE_NOTES.md
@@ -1,3 +1,10 @@
+# 5.8.0
+* Mapped the new Mini Games surface from the native SDKs' Minigames epic through the React Native library:
+  * Added `LucraSDK.getMiniGames(): Promise<MiniGameCatalogItem[]>` — a headless function that lists every mini game enabled for the current tenant, each with the tenant's subscribed config options (mode, wager amount, group size). No Lucra UI is presented.
+  * Added the exported `MiniGameCatalogItem` and `MiniGameCatalogConfig` TypeScript types describing the catalog response.
+  * Added the Lucra-managed `MINI_GAMES_HOME` flow: `LucraSDK.present({ name: LucraSDK.FLOW.MINI_GAMES_HOME })`. This presents the Mini Games home experience (profile, achievements, game carousel, and featured tournament); its sub-screens (profile, rewards, matchup details, game-mode selection) are reachable by navigating within the flow.
+* Cross-platform parity: both Android and iOS return identical `MiniGameCatalogItem`/`MiniGameCatalogConfig` shapes.
+
 # 5.7.0
 * Added `autoJoin` boolean to `LucraSDKParams` (optional, defaults to `true`). When `true`, the SDK automatically joins all eligible free-entry tournaments as soon as the user authenticates. Set to `false` to suppress automatic joining and drive it yourself.
   * Passed through to `LucraClient.initialize(autoJoin:)` on Android and `LucraEnvironmentOverrides.init(autoJoin:)` on iOS. Both platforms previously hardcoded their own defaults (Android `true`, iOS `false`); the bridge now makes `true` the explicit cross-platform default.

--- a/docs/SDK_RELEASE_NOTES.md
+++ b/docs/SDK_RELEASE_NOTES.md
@@ -2,8 +2,12 @@
 * Mapped the new Mini Games surface from the native SDKs' Minigames epic through the React Native library:
   * Added `LucraSDK.getMiniGames(): Promise<MiniGameCatalogItem[]>` — a headless function that lists every mini game enabled for the current tenant, each with the tenant's subscribed config options (mode, wager amount, group size). No Lucra UI is presented.
   * Added the exported `MiniGameCatalogItem` and `MiniGameCatalogConfig` TypeScript types describing the catalog response.
-  * Added the Lucra-managed `MINI_GAMES_HOME` flow: `LucraSDK.present({ name: LucraSDK.FLOW.MINI_GAMES_HOME })`. This presents the Mini Games home experience (profile, achievements, game carousel, and featured tournament); its sub-screens (profile, rewards, matchup details, game-mode selection) are reachable by navigating within the flow.
-* Cross-platform parity: both Android and iOS return identical `MiniGameCatalogItem`/`MiniGameCatalogConfig` shapes.
+  * Added the Lucra-managed Mini Games flows, presented via `LucraSDK.present({ name: … })`:
+    * `MINI_GAMES_HOME` — the Mini Games home experience (profile pill, achievement card, game carousel, featured tournament).
+    * `MINI_GAMES_PROFILE` — the Mini Games profile (avatar, username, balance, stats, recent results).
+    * `MINI_GAMES_REWARDS` — the Mini Games rewards screen (achievement rewards grouped by game).
+    * `MINI_GAMES_MATCHUP_DETAILS` — the Mini Games matchup result screen (requires `matchupId`).
+* Cross-platform parity: both Android and iOS expose the same Mini Games flows and return identical `MiniGameCatalogItem`/`MiniGameCatalogConfig` shapes.
 
 # 5.7.0
 * Added `autoJoin` boolean to `LucraSDKParams` (optional, defaults to `true`). When `true`, the SDK automatically joins all eligible free-entry tournaments as soon as the user authenticates. Set to `false` to suppress automatic joining and drive it yourself.

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -100,11 +100,11 @@ PODS:
     - hermes-engine/Pre-built (= 0.79.2)
   - hermes-engine/Pre-built (0.79.2)
   - JWTDecode (3.3.0)
-  - lucra-react-native-sdk (5.5.0):
+  - lucra-react-native-sdk (5.8.0):
     - DoubleConversion
     - glog
     - hermes-engine
-    - LucraSDK (= 5.5.0)
+    - LucraSDK (= 5.6.0)
     - RCT-Folly (= 2024.11.18.00)
     - RCTRequired
     - RCTTypeSafety
@@ -125,7 +125,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - LucraSDK (5.5.0):
+  - LucraSDK (5.6.0):
     - Auth0
   - nanopb (3.30910.0):
     - nanopb/decode (= 3.30910.0)
@@ -2419,8 +2419,8 @@ SPEC CHECKSUMS:
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
   hermes-engine: 314be5250afa5692b57b4dd1705959e1973a8ebe
   JWTDecode: 1ca6f765844457d0dd8690436860fecee788f631
-  lucra-react-native-sdk: 4b7a8572afa80a3ac9f74badfbbe673be47aa08d
-  LucraSDK: bd3c23378edf22807cc88ed1d4d9b218546d28f0
+  lucra-react-native-sdk: 537a57d13afe8c4242a524f1715462fa12b65056
+  LucraSDK: afba2cea6e5d5f57b6d6d4f7cc240369f68e6c3b
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   RCT-Folly: e78785aa9ba2ed998ea4151e314036f6c49e6d82
@@ -2505,4 +2505,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 057413d3ec6fc9cc94d5ef21a76854377931b31f
 
-COCOAPODS: 1.16.2
+COCOAPODS: 1.15.2

--- a/example/package.json
+++ b/example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example",
-  "version": "5.5.0",
+  "version": "5.8.0",
   "private": true,
   "scripts": {
     "android": "react-native run-android",

--- a/example/src/container/Main.container.tsx
+++ b/example/src/container/Main.container.tsx
@@ -15,6 +15,7 @@ import type { RootStackParamList } from '../Routes';
 import { ClientOverride } from './ClientOverride';
 import { ColorOverride } from './ColorOverride';
 import { useAppContext } from '../AppContext';
+import { LucraSDK } from '@lucra-sports/lucra-react-native-sdk';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Main'>;
 
@@ -66,6 +67,14 @@ export const MainContainer: React.FC<Props> = ({ navigation }) => {
             }}
           >
             <Text className="text-white">Mini Game Launcher</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            className="bg-indigo-700 p-4"
+            onPress={() => {
+              LucraSDK.present({ name: LucraSDK.FLOW.MINI_GAMES_HOME });
+            }}
+          >
+            <Text className="text-white">Mini Games Home</Text>
           </TouchableOpacity>
           <TouchableOpacity
             className="bg-indigo-700 p-4 rounded-b-xl"

--- a/example/src/container/Main.container.tsx
+++ b/example/src/container/Main.container.tsx
@@ -6,6 +6,7 @@ import {
   SafeAreaView,
   ScrollView,
   Text,
+  TextInput,
   TouchableOpacity,
   Button,
   Alert,
@@ -21,6 +22,7 @@ type Props = NativeStackScreenProps<RootStackParamList, 'Main'>;
 
 export const MainContainer: React.FC<Props> = ({ navigation }) => {
   const { state } = useAppContext();
+  const [miniGamesMatchupId, setMiniGamesMatchupId] = React.useState('');
   return (
     <SafeAreaView className="flex-1">
       <ScrollView className="flex-1" contentContainerClassName="p-4">
@@ -75,6 +77,50 @@ export const MainContainer: React.FC<Props> = ({ navigation }) => {
             }}
           >
             <Text className="text-white">Mini Games Home</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            className="bg-indigo-700 p-4"
+            onPress={() => {
+              LucraSDK.present({ name: LucraSDK.FLOW.MINI_GAMES_PROFILE });
+            }}
+          >
+            <Text className="text-white">Mini Games Profile</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            className="bg-indigo-700 p-4"
+            onPress={() => {
+              LucraSDK.present({ name: LucraSDK.FLOW.MINI_GAMES_REWARDS });
+            }}
+          >
+            <Text className="text-white">Mini Games Rewards</Text>
+          </TouchableOpacity>
+          <TextInput
+            className="bg-indigo-900 text-white p-4"
+            placeholder="Matchup ID (for Matchup Details)"
+            placeholderTextColor="#a5b4fc"
+            autoCapitalize="none"
+            autoCorrect={false}
+            value={miniGamesMatchupId}
+            onChangeText={setMiniGamesMatchupId}
+          />
+          <TouchableOpacity
+            className="bg-indigo-700 p-4"
+            onPress={() => {
+              const id = miniGamesMatchupId.trim();
+              if (!id) {
+                Alert.alert(
+                  'Matchup ID required',
+                  'Enter a matchup ID above first.'
+                );
+                return;
+              }
+              LucraSDK.present({
+                name: LucraSDK.FLOW.MINI_GAMES_MATCHUP_DETAILS,
+                matchupId: id,
+              });
+            }}
+          >
+            <Text className="text-white">Mini Games Matchup Details</Text>
           </TouchableOpacity>
           <TouchableOpacity
             className="bg-indigo-700 p-4 rounded-b-xl"

--- a/ios/Libs/LucraMapper.swift
+++ b/ios/Libs/LucraMapper.swift
@@ -737,6 +737,12 @@ public func lucraFlowToMap(_ flow: LucraSDK.LucraFlow) -> [String: Any] {
     return ["flow": "notifications"]
   case .miniGamesHome:
     return ["flow": "miniGamesHome"]
+  case .miniGamesProfile:
+    return ["flow": "miniGamesProfile"]
+  case .miniGamesRewards:
+    return ["flow": "miniGamesRewards"]
+  case .miniGamesMatchupDetails(let matchupId):
+    return ["flow": "miniGamesMatchupDetails", "matchupId": matchupId]
   case .miniGame(let gameId, let gameMode, let amount, let matchupId, _):
     // JS-facing mode strings (MiniGameMode enum), not the native rawValues
     let modeString: String

--- a/ios/Libs/LucraMapper.swift
+++ b/ios/Libs/LucraMapper.swift
@@ -661,6 +661,31 @@ public func userAchievementToMap(_ achievement: LucraSDK.UserAchievement) -> [St
   ]
 }
 
+public func miniGameCatalogConfigToMap(_ config: LucraSDK.MiniGameCatalogConfig) -> [String: Any?] {
+  return [
+    "id": config.id,
+    "gameId": config.gameId,
+    "mode": config.mode,
+    "wagerAmount": config.wagerAmount.map { NSDecimalNumber(decimal: $0).doubleValue },
+    "groupSize": config.groupSize,
+    "createdAt": config.createdAt,
+    "updatedAt": config.updatedAt,
+  ]
+}
+
+public func miniGameCatalogItemToMap(_ item: LucraSDK.MiniGameCatalogItem) -> [String: Any?] {
+  return [
+    "gameId": item.gameId,
+    "name": item.name,
+    "description": item.description,
+    "imageUrl": item.imageUrl,
+    "videoUrl": item.videoUrl,
+    "createdAt": item.createdAt,
+    "updatedAt": item.updatedAt,
+    "config": item.config.map { miniGameCatalogConfigToMap($0) },
+  ]
+}
+
 public func lucraFlowToMap(_ flow: LucraSDK.LucraFlow) -> [String: Any] {
   switch flow {
   case .onboarding:
@@ -710,7 +735,9 @@ public func lucraFlowToMap(_ flow: LucraSDK.LucraFlow) -> [String: Any] {
     return ["flow": "responsibleGaming"]
   case .notifications:
     return ["flow": "notifications"]
-  case .miniGame(let gameId, let gameMode, let amount, let matchupId):
+  case .miniGamesHome:
+    return ["flow": "miniGamesHome"]
+  case .miniGame(let gameId, let gameMode, let amount, let matchupId, _):
     // JS-facing mode strings (MiniGameMode enum), not the native rawValues
     let modeString: String
     switch gameMode {

--- a/ios/Libs/LucraUtils.swift
+++ b/ios/Libs/LucraUtils.swift
@@ -81,6 +81,12 @@ class LucraUtils {
         handlePostNavigation: false)
     case "miniGamesHome":
       return .miniGamesHome
+    case "miniGamesProfile":
+      return .miniGamesProfile
+    case "miniGamesRewards":
+      return .miniGamesRewards
+    case "miniGamesMatchupDetails":
+      return .miniGamesMatchupDetails(matchupId: matchupId!)
     case "achievements":
       return .achievements
     default:

--- a/ios/Libs/LucraUtils.swift
+++ b/ios/Libs/LucraUtils.swift
@@ -77,7 +77,10 @@ class LucraUtils {
           userInfo: [NSLocalizedDescriptionKey: "miniGame flow requires a valid gameMode"])
       }
       return .miniGame(
-        gameId: gameId, gameMode: parsedMode, amount: amount, matchupId: matchupId)
+        gameId: gameId, gameMode: parsedMode, amount: amount, matchupId: matchupId,
+        handlePostNavigation: false)
+    case "miniGamesHome":
+      return .miniGamesHome
     case "achievements":
       return .achievements
     default:

--- a/ios/LucraClient.mm
+++ b/ios/LucraClient.mm
@@ -62,6 +62,11 @@ RCT_EXPORT_METHOD(startMiniGame : (NSString *)gameId
                       reject:reject];
 }
 
+RCT_EXPORT_METHOD(getMiniGames : (RCTPromiseResolveBlock)resolve
+                  reject : (RCTPromiseRejectBlock)reject) {
+  [swiftClient getMiniGames:resolve reject:reject];
+}
+
 RCT_EXPORT_METHOD(getUserTournamentRewards : (NSDictionary *)params
                   resolve : (RCTPromiseResolveBlock)resolve
                   reject : (RCTPromiseRejectBlock)reject) {

--- a/ios/LucraSwiftClient.swift
+++ b/ios/LucraSwiftClient.swift
@@ -665,6 +665,22 @@ private enum ErrorCode {
       }
     }
 
+    @objc public func getMiniGames(
+      _ resolve: @escaping RCTPromiseResolveBlock,
+      reject: @escaping RCTPromiseRejectBlock
+    ) {
+      Task { @MainActor in
+        let result = await self.nativeClient.api.getMiniGames()
+
+        switch result {
+        case .success(let games):
+          resolve(games.map { miniGameCatalogItemToMap($0) })
+        case .failure(let error):
+          rejectLucraError(reject, error: error)
+        }
+      }
+    }
+
     private func rejectLucraError(_ reject: RCTPromiseRejectBlock, error: Error) {
       let (code, message) = lucraErrorCodeMessage(error)
       reject(code, message, error)

--- a/lucra-react-native-sdk.podspec
+++ b/lucra-react-native-sdk.podspec
@@ -39,7 +39,7 @@ Pod::Spec.new do |s|
     s.dependency 'Auth0'
   else
     s.source = { :git => "https://github.com/Lucra-Sports/lucra-react-native-sdk", :tag => "#{s.version}" }
-    s.dependency 'LucraSDK', '5.5.0'
+    s.dependency 'LucraSDK', '5.6.0'
   end
   
   if fabric_enabled

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lucra-sports/lucra-react-native-sdk",
-  "version": "5.5.0",
+  "version": "5.8.0",
   "description": "Lucra React Native SDK",
   "main": "lib/module/index.js",
   "types": "./lib/typescript/src/index.d.ts",

--- a/src/NativeLucraClient.ts
+++ b/src/NativeLucraClient.ts
@@ -43,6 +43,7 @@ interface Spec extends TurboModule {
     amount: number,
     matchupId: string
   ): Promise<Object>;
+  getMiniGames(): Promise<Object[]>;
 
   // Rewards & Achievements headless (Minigames Headless epic)
   getUserTournamentRewards(params: Object): Promise<Object[]>;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -157,6 +157,27 @@ export type MiniGameFinishedEvent = {
   matchupId?: string;
 };
 
+export type MiniGameCatalogConfig = {
+  id: string;
+  gameId: string;
+  mode: string;
+  wagerAmount?: number;
+  groupSize?: number;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type MiniGameCatalogItem = {
+  gameId: string;
+  name: string;
+  description?: string;
+  imageUrl?: string;
+  videoUrl?: string;
+  createdAt: string;
+  updatedAt: string;
+  config: MiniGameCatalogConfig[];
+};
+
 export enum LucraEnvironment {
   PRODUCTION = 'production',
   STAGING = 'staging',
@@ -518,6 +539,7 @@ const Flows = {
   WALLET: 'wallet',
   HOME_PAGE: 'homePage',
   MINI_GAME: 'miniGame',
+  MINI_GAMES_HOME: 'miniGamesHome',
   ACHIEVEMENTS: 'achievements',
   // SPORT_CONTEST_DETAILS: 'sportContestDetails',
 } as const;
@@ -560,6 +582,7 @@ function present(params: {
   matchupId?: string;
 }): Promise<void>;
 function present(params: { name: typeof Flows.ACHIEVEMENTS }): Promise<void>;
+function present(params: { name: typeof Flows.MINI_GAMES_HOME }): Promise<void>;
 function present(params: {
   name: FlowNames;
   gameId?: string;
@@ -827,6 +850,10 @@ export const LucraSDK = {
   },
   markAchievementViewed: (userAchievementId: string): Promise<void> => {
     return LucraClient.markAchievementViewed(userAchievementId);
+  },
+  /** Lists every mini game enabled for the current tenant, each with the tenant's subscribed config options. */
+  getMiniGames: async (): Promise<MiniGameCatalogItem[]> => {
+    return (await LucraClient.getMiniGames()) as MiniGameCatalogItem[];
   },
   getMatchup: async (matchupId: string): Promise<MatchupInfo> => {
     return (await LucraClient.getMatchup(matchupId)) as MatchupInfo;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -540,6 +540,9 @@ const Flows = {
   HOME_PAGE: 'homePage',
   MINI_GAME: 'miniGame',
   MINI_GAMES_HOME: 'miniGamesHome',
+  MINI_GAMES_PROFILE: 'miniGamesProfile',
+  MINI_GAMES_REWARDS: 'miniGamesRewards',
+  MINI_GAMES_MATCHUP_DETAILS: 'miniGamesMatchupDetails',
   ACHIEVEMENTS: 'achievements',
   // SPORT_CONTEST_DETAILS: 'sportContestDetails',
 } as const;
@@ -583,6 +586,16 @@ function present(params: {
 }): Promise<void>;
 function present(params: { name: typeof Flows.ACHIEVEMENTS }): Promise<void>;
 function present(params: { name: typeof Flows.MINI_GAMES_HOME }): Promise<void>;
+function present(params: {
+  name: typeof Flows.MINI_GAMES_PROFILE;
+}): Promise<void>;
+function present(params: {
+  name: typeof Flows.MINI_GAMES_REWARDS;
+}): Promise<void>;
+function present(params: {
+  name: typeof Flows.MINI_GAMES_MATCHUP_DETAILS;
+  matchupId: string;
+}): Promise<void>;
 function present(params: {
   name: FlowNames;
   gameId?: string;


### PR DESCRIPTION
This PR updates the React Native SDK to 5.8.0 and adds the new MiniGames work to React Native.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added `LucraSDK.getMiniGames()` to fetch the enabled mini-game catalog (tenant-scoped).
  * Added new mini-game presentation flows: Home, Profile, Rewards, and Matchup Details, with `matchupId` required for Matchup Details.
  * Exposed new catalog types for mini-game items and per-mode configuration.

* **Documentation**
  * Updated flow documentation and added headless mini-games usage guidance with TypeScript examples.

* **Chores**
  * Bumped SDK/package versions and updated iOS/Android SDK versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->