### PR TITLE
Trim CodeRabbit tone_instructions to fit 250-char limit

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -14,10 +14,10 @@
 
 language: en-US
 tone_instructions: >-
-  You are reviewing a public-facing SDK consumed by external integrators.
-  Treat cross-platform (iOS/Android) parity, documentation accuracy, and
-  release-note accuracy as first-class review concerns alongside correctness.
-  Be specific: name the exact file that is out of sync.
+  You are reviewing a public-facing SDK used by external integrators.
+  Treat cross-platform (iOS/Android) parity, doc accuracy, and
+  release-note accuracy as first-class concerns alongside correctness.
+  Be specific: name the exact file out of sync.
 
 early_access: false
 


### PR DESCRIPTION
## Summary
- Shortened `tone_instructions` in `.coderabbit.yaml` from 272 to 248 characters to comply with the 250-character limit
- No semantic changes — same review guidance, just tighter wording

## Test plan
- [ ] Verify CodeRabbit accepts the config without validation errors on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined review guidance for clearer, more specific feedback.
  * Added emphasis on identifying the exact file when inconsistencies are found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->